### PR TITLE
Remove references to key lifetime

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -19,7 +19,7 @@ use std::process::{Command, Output};
 
 const PROTO_FOLDER: &str = "target/parsec-operations/protobuf";
 const PROTO_OUT_DIR: &str = "src/operations_protobuf/generated_ops";
-const PARSEC_OPERATIONS_VERSION: &str = "0.1.0";
+const PARSEC_OPERATIONS_VERSION: &str = "0.2.0";
 
 // TODO: handle OsStrings more carefully, as .into_string() might fail
 

--- a/src/operations/asym_sign.rs
+++ b/src/operations/asym_sign.rs
@@ -12,11 +12,10 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use super::key_attributes::KeyLifetime;
 
 /// Native object for asymmetric sign operations.
 ///
-/// `key_name` and `key_lifetime` define which key should be used for the signing operation.
+/// `key_name` defines which key should be used for the signing operation.
 /// The `hash` value must either be a short message (length dependend on the size of
 /// the key), or the result of a hashing operation. Thus, if a hash-and-sign is
 /// required, the hash must be computed before this operation is called. The length
@@ -27,7 +26,6 @@ use super::key_attributes::KeyLifetime;
 #[derive(Debug)]
 pub struct OpAsymSign {
     pub key_name: String,
-    pub key_lifetime: KeyLifetime,
     pub hash: Vec<u8>,
 }
 

--- a/src/operations/asym_verify.rs
+++ b/src/operations/asym_verify.rs
@@ -12,11 +12,10 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use super::key_attributes::KeyLifetime;
 
 /// Native object for asymmetric verification of signatures.
 ///
-/// `key_name` and `key_lifetime` specify the key to be used for verification.
+/// `key_name` specifies the key to be used for verification.
 /// The `hash` contains a short message or hash value as described for the
 /// asymmetric signing operation.
 /// `signature` contains the bytes of the signature which requires validation and must
@@ -24,7 +23,6 @@ use super::key_attributes::KeyLifetime;
 #[derive(Debug)]
 pub struct OpAsymVerify {
     pub key_name: String,
-    pub key_lifetime: KeyLifetime,
     pub hash: Vec<u8>,
     pub signature: Vec<u8>,
 }

--- a/src/operations/destroy_key.rs
+++ b/src/operations/destroy_key.rs
@@ -12,15 +12,13 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use super::key_attributes::KeyLifetime;
 
 /// Native object for cryptographic key destruction.
 ///
-/// `key_name` and `key_lifetime` identify the key to be destroyed.
+/// `key_name` identifies the key to be destroyed.
 #[derive(Debug, Clone)]
 pub struct OpDestroyKey {
     pub key_name: String,
-    pub key_lifetime: KeyLifetime,
 }
 
 /// Native object for result of cryptographic key destruction.

--- a/src/operations/export_public_key.rs
+++ b/src/operations/export_public_key.rs
@@ -12,15 +12,13 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use super::key_attributes::KeyLifetime;
 
 /// Native object for public key exporting operation.
 ///
-/// `key_name` and `key_lifetime` identify the key for which the public
+/// `key_name` identifies the key for which the public
 /// part will be exported. The specified key must be an asymmetric keypair.
 pub struct OpExportPublicKey {
     pub key_name: String,
-    pub key_lifetime: KeyLifetime,
 }
 
 /// Native object for result of public key export operation.

--- a/src/operations/key_attributes.rs
+++ b/src/operations/key_attributes.rs
@@ -98,7 +98,6 @@ impl Algorithm {
 /// a cryptographic key.
 #[derive(Clone)]
 pub struct KeyAttributes {
-    pub key_lifetime: KeyLifetime,
     pub key_type: KeyType,
     pub ecc_curve: Option<EccCurve>,
     pub algorithm: Algorithm,
@@ -109,14 +108,6 @@ pub struct KeyAttributes {
     pub permit_sign: bool,
     pub permit_verify: bool,
     pub permit_derive: bool,
-}
-
-#[derive(FromPrimitive, Copy, Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
-#[repr(i32)]
-pub enum KeyLifetime {
-    Volatile = 0,
-    Persistent = 1,
 }
 
 /// Enumeration of key types supported.

--- a/src/operations_protobuf/convert_asym_sign.rs
+++ b/src/operations_protobuf/convert_asym_sign.rs
@@ -15,7 +15,6 @@
 use super::generated_ops::asym_sign::{OpAsymmetricSignProto, ResultAsymmetricSignProto};
 use crate::operations::{OpAsymSign, ResultAsymSign};
 use crate::requests::ResponseStatus;
-use num::FromPrimitive;
 use std::convert::TryFrom;
 
 impl TryFrom<OpAsymmetricSignProto> for OpAsymSign {
@@ -24,8 +23,6 @@ impl TryFrom<OpAsymmetricSignProto> for OpAsymSign {
     fn try_from(proto_op: OpAsymmetricSignProto) -> Result<Self, Self::Error> {
         Ok(OpAsymSign {
             key_name: proto_op.key_name,
-            key_lifetime: FromPrimitive::from_i32(proto_op.key_lifetime)
-                .expect("Failed to convert key lifetime"),
             hash: proto_op.hash,
         })
     }
@@ -37,7 +34,6 @@ impl TryFrom<OpAsymSign> for OpAsymmetricSignProto {
     fn try_from(op: OpAsymSign) -> Result<Self, Self::Error> {
         Ok(OpAsymmetricSignProto {
             key_name: op.key_name,
-            key_lifetime: op.key_lifetime as i32,
             hash: op.hash,
         })
     }
@@ -69,9 +65,7 @@ mod test {
         OpAsymmetricSignProto, ResultAsymmetricSignProto,
     };
     use super::super::{Convert, ProtobufConverter};
-    use crate::operations::{
-        key_attributes, NativeOperation, NativeResult, OpAsymSign, ResultAsymSign,
-    };
+    use crate::operations::{NativeOperation, NativeResult, OpAsymSign, ResultAsymSign};
     use crate::requests::{request::RequestBody, response::ResponseBody, Opcode};
     use std::convert::TryInto;
 
@@ -83,13 +77,11 @@ mod test {
         let hash = vec![0x11, 0x22, 0x33];
         let key_name = "test name".to_string();
         proto.hash = hash.clone();
-        proto.key_lifetime = key_attributes::KeyLifetime::Persistent as i32;
         proto.key_name = key_name.clone();
 
         let op: OpAsymSign = proto.try_into().expect("Failed to convert");
 
         assert_eq!(op.hash, hash);
-        assert_eq!(op.key_lifetime, key_attributes::KeyLifetime::Persistent);
         assert_eq!(op.key_name, key_name);
     }
 
@@ -100,17 +92,12 @@ mod test {
 
         let op = OpAsymSign {
             hash: hash.clone(),
-            key_lifetime: key_attributes::KeyLifetime::Persistent,
             key_name: key_name.clone(),
         };
 
         let proto: OpAsymmetricSignProto = op.try_into().expect("Failed to convert");
 
         assert_eq!(proto.hash, hash);
-        assert_eq!(
-            proto.key_lifetime,
-            key_attributes::KeyLifetime::Persistent as i32
-        );
         assert_eq!(proto.key_name, key_name);
     }
 
@@ -141,7 +128,6 @@ mod test {
     fn op_asym_sign_e2e() {
         let op = OpAsymSign {
             hash: vec![0x11, 0x22, 0x33],
-            key_lifetime: key_attributes::KeyLifetime::Persistent,
             key_name: "test name".to_string(),
         };
         let body = CONVERTER

--- a/src/operations_protobuf/convert_asym_verify.rs
+++ b/src/operations_protobuf/convert_asym_verify.rs
@@ -15,7 +15,6 @@
 use super::generated_ops::asym_verify::{OpAsymmetricVerifyProto, ResultAsymmetricVerifyProto};
 use crate::operations::{OpAsymVerify, ResultAsymVerify};
 use crate::requests::ResponseStatus;
-use num::FromPrimitive;
 use std::convert::TryFrom;
 
 impl TryFrom<OpAsymmetricVerifyProto> for OpAsymVerify {
@@ -24,8 +23,6 @@ impl TryFrom<OpAsymmetricVerifyProto> for OpAsymVerify {
     fn try_from(proto_op: OpAsymmetricVerifyProto) -> Result<Self, Self::Error> {
         Ok(OpAsymVerify {
             key_name: proto_op.key_name,
-            key_lifetime: FromPrimitive::from_i32(proto_op.key_lifetime)
-                .expect("Failed to convert key lifetime"),
             hash: proto_op.hash,
             signature: proto_op.signature,
         })
@@ -38,7 +35,6 @@ impl TryFrom<OpAsymVerify> for OpAsymmetricVerifyProto {
     fn try_from(op: OpAsymVerify) -> Result<Self, Self::Error> {
         Ok(OpAsymmetricVerifyProto {
             key_name: op.key_name,
-            key_lifetime: op.key_lifetime as i32,
             hash: op.hash,
             signature: op.signature,
         })
@@ -67,9 +63,7 @@ mod test {
         OpAsymmetricVerifyProto, ResultAsymmetricVerifyProto,
     };
     use super::super::{Convert, ProtobufConverter};
-    use crate::operations::{
-        key_attributes, NativeOperation, NativeResult, OpAsymVerify, ResultAsymVerify,
-    };
+    use crate::operations::{NativeOperation, NativeResult, OpAsymVerify, ResultAsymVerify};
     use crate::requests::{request::RequestBody, response::ResponseBody, Opcode};
     use std::convert::TryInto;
 
@@ -82,14 +76,12 @@ mod test {
         let key_name = "test name".to_string();
         let signature = vec![0x11, 0x22, 0x33];
         proto.hash = hash.clone();
-        proto.key_lifetime = key_attributes::KeyLifetime::Persistent as i32;
         proto.key_name = key_name.clone();
         proto.signature = signature.clone();
 
         let op: OpAsymVerify = proto.try_into().expect("Failed to convert");
 
         assert_eq!(op.hash, hash);
-        assert_eq!(op.key_lifetime, key_attributes::KeyLifetime::Persistent);
         assert_eq!(op.key_name, key_name);
         assert_eq!(op.signature, signature);
     }
@@ -102,7 +94,6 @@ mod test {
 
         let op = OpAsymVerify {
             hash: hash.clone(),
-            key_lifetime: key_attributes::KeyLifetime::Persistent,
             key_name: key_name.clone(),
             signature: signature.clone(),
         };
@@ -110,10 +101,6 @@ mod test {
         let proto: OpAsymmetricVerifyProto = op.try_into().expect("Failed to convert");
 
         assert_eq!(proto.hash, hash);
-        assert_eq!(
-            proto.key_lifetime,
-            key_attributes::KeyLifetime::Persistent as i32
-        );
         assert_eq!(proto.key_name, key_name);
         assert_eq!(proto.signature, signature);
     }
@@ -136,7 +123,6 @@ mod test {
     fn op_asym_sign_e2e() {
         let op = OpAsymVerify {
             hash: vec![0x11, 0x22, 0x33],
-            key_lifetime: key_attributes::KeyLifetime::Persistent,
             key_name: "test name".to_string(),
             signature: vec![0x11, 0x22, 0x33],
         };

--- a/src/operations_protobuf/convert_create_key.rs
+++ b/src/operations_protobuf/convert_create_key.rs
@@ -130,7 +130,6 @@ mod test {
 
     fn get_key_attrs() -> KeyAttributes {
         KeyAttributes {
-            key_lifetime: key_attributes::KeyLifetime::Persistent,
             key_type: key_attributes::KeyType::RsaKeypair,
             ecc_curve: Some(key_attributes::EccCurve::Secp160k1),
             algorithm: key_attributes::Algorithm::sign(
@@ -153,7 +152,6 @@ mod test {
             hash_algorithm: key_attributes_proto::HashAlgorithm::Sha1 as i32,
         }));
         KeyAttributesProto {
-            key_lifetime: key_attributes_proto::KeyLifetime::Persistent as i32,
             key_type: key_attributes_proto::KeyType::RsaKeypair as i32,
             ecc_curve: key_attributes_proto::EccCurve::Secp160k1 as i32,
             algorithm_proto: algo,

--- a/src/operations_protobuf/convert_destroy_key.rs
+++ b/src/operations_protobuf/convert_destroy_key.rs
@@ -15,7 +15,6 @@
 use super::generated_ops::destroy_key::{OpDestroyKeyProto, ResultDestroyKeyProto};
 use crate::operations::{OpDestroyKey, ResultDestroyKey};
 use crate::requests::ResponseStatus;
-use num::FromPrimitive;
 use std::convert::TryFrom;
 
 impl TryFrom<OpDestroyKeyProto> for OpDestroyKey {
@@ -24,8 +23,6 @@ impl TryFrom<OpDestroyKeyProto> for OpDestroyKey {
     fn try_from(proto_op: OpDestroyKeyProto) -> Result<Self, Self::Error> {
         Ok(OpDestroyKey {
             key_name: proto_op.key_name,
-            key_lifetime: FromPrimitive::from_i32(proto_op.key_lifetime)
-                .expect("Failed to convert key lifetime"),
         })
     }
 }
@@ -36,7 +33,6 @@ impl TryFrom<OpDestroyKey> for OpDestroyKeyProto {
     fn try_from(op: OpDestroyKey) -> Result<Self, Self::Error> {
         Ok(OpDestroyKeyProto {
             key_name: op.key_name,
-            key_lifetime: op.key_lifetime as i32,
         })
     }
 }
@@ -61,7 +57,7 @@ impl TryFrom<ResultDestroyKey> for ResultDestroyKeyProto {
 mod test {
     use super::super::generated_ops::destroy_key::{OpDestroyKeyProto, ResultDestroyKeyProto};
     use super::super::{Convert, ProtobufConverter};
-    use crate::operations::{key_attributes, NativeOperation, OpDestroyKey, ResultDestroyKey};
+    use crate::operations::{NativeOperation, OpDestroyKey, ResultDestroyKey};
     use crate::requests::{request::RequestBody, response::ResponseBody, Opcode};
     use std::convert::TryInto;
 
@@ -71,12 +67,10 @@ mod test {
     fn destroy_key_proto_to_op() {
         let mut proto: OpDestroyKeyProto = Default::default();
         let key_name = "test name".to_string();
-        proto.key_lifetime = key_attributes::KeyLifetime::Persistent as i32;
         proto.key_name = key_name.clone();
 
         let op: OpDestroyKey = proto.try_into().expect("Failed to convert");
 
-        assert_eq!(op.key_lifetime, key_attributes::KeyLifetime::Persistent);
         assert_eq!(op.key_name, key_name);
     }
 
@@ -84,16 +78,11 @@ mod test {
     fn destroy_key_op_to_proto() {
         let key_name = "test name".to_string();
         let op = OpDestroyKey {
-            key_lifetime: key_attributes::KeyLifetime::Persistent,
             key_name: key_name.clone(),
         };
 
         let proto: OpDestroyKeyProto = op.try_into().expect("Failed to convert");
 
-        assert_eq!(
-            proto.key_lifetime,
-            key_attributes::KeyLifetime::Persistent as i32
-        );
         assert_eq!(proto.key_name, key_name);
     }
 
@@ -114,7 +103,6 @@ mod test {
     #[test]
     fn op_destroy_key_e2e() {
         let op = OpDestroyKey {
-            key_lifetime: key_attributes::KeyLifetime::Persistent,
             key_name: "test name".to_string(),
         };
         let body = CONVERTER

--- a/src/operations_protobuf/convert_export_public_key.rs
+++ b/src/operations_protobuf/convert_export_public_key.rs
@@ -15,19 +15,14 @@
 use super::generated_ops::export_public_key::{OpExportPublicKeyProto, ResultExportPublicKeyProto};
 use crate::operations;
 use crate::requests::ResponseStatus;
-use num::FromPrimitive;
 use std::convert::TryFrom;
 
 impl TryFrom<OpExportPublicKeyProto> for operations::OpExportPublicKey {
     type Error = ResponseStatus;
 
     fn try_from(proto_op: OpExportPublicKeyProto) -> Result<Self, Self::Error> {
-        let key_lifetime =
-            FromPrimitive::from_i32(proto_op.key_lifetime).expect("Failed to convert key lifetime");
-
         Ok(operations::OpExportPublicKey {
             key_name: proto_op.key_name,
-            key_lifetime,
         })
     }
 }
@@ -38,7 +33,6 @@ impl TryFrom<operations::OpExportPublicKey> for OpExportPublicKeyProto {
     fn try_from(op: operations::OpExportPublicKey) -> Result<Self, Self::Error> {
         Ok(OpExportPublicKeyProto {
             key_name: op.key_name,
-            key_lifetime: op.key_lifetime as i32,
         })
     }
 }
@@ -70,7 +64,7 @@ mod test {
     };
     use super::super::{Convert, ProtobufConverter};
     use crate::operations::{
-        key_attributes, NativeOperation, NativeResult, OpExportPublicKey, ResultExportPublicKey,
+        NativeOperation, NativeResult, OpExportPublicKey, ResultExportPublicKey,
     };
     use crate::requests::{request::RequestBody, response::ResponseBody, Opcode};
     use std::convert::TryInto;
@@ -81,12 +75,10 @@ mod test {
     fn export_pk_proto_to_op() {
         let mut proto: OpExportPublicKeyProto = Default::default();
         let key_name = "test name".to_string();
-        proto.key_lifetime = key_attributes::KeyLifetime::Persistent as i32;
         proto.key_name = key_name.clone();
 
         let op: OpExportPublicKey = proto.try_into().expect("Failed to convert");
 
-        assert_eq!(op.key_lifetime, key_attributes::KeyLifetime::Persistent);
         assert_eq!(op.key_name, key_name);
     }
 
@@ -95,16 +87,11 @@ mod test {
         let key_name = "test name".to_string();
 
         let op = OpExportPublicKey {
-            key_lifetime: key_attributes::KeyLifetime::Persistent,
             key_name: key_name.clone(),
         };
 
         let proto: OpExportPublicKeyProto = op.try_into().expect("Failed to convert");
 
-        assert_eq!(
-            proto.key_lifetime,
-            key_attributes::KeyLifetime::Persistent as i32
-        );
         assert_eq!(proto.key_name, key_name);
     }
 
@@ -134,7 +121,6 @@ mod test {
     #[test]
     fn op_export_pk_e2e() {
         let op = OpExportPublicKey {
-            key_lifetime: key_attributes::KeyLifetime::Persistent,
             key_name: "test name".to_string(),
         };
         let body = CONVERTER

--- a/src/operations_protobuf/convert_import_key.rs
+++ b/src/operations_protobuf/convert_import_key.rs
@@ -138,7 +138,6 @@ mod test {
 
     fn get_key_attrs() -> KeyAttributes {
         KeyAttributes {
-            key_lifetime: key_attributes::KeyLifetime::Persistent,
             key_type: key_attributes::KeyType::RsaKeypair,
             ecc_curve: Some(key_attributes::EccCurve::Secp160k1),
             algorithm: key_attributes::Algorithm::sign(
@@ -161,7 +160,6 @@ mod test {
             hash_algorithm: key_attributes_proto::HashAlgorithm::Sha1 as i32,
         }));
         KeyAttributesProto {
-            key_lifetime: key_attributes_proto::KeyLifetime::Persistent as i32,
             key_type: key_attributes_proto::KeyType::RsaKeypair as i32,
             ecc_curve: key_attributes_proto::EccCurve::Secp160k1 as i32,
             algorithm_proto: algo,

--- a/src/operations_protobuf/convert_key_attributes.rs
+++ b/src/operations_protobuf/convert_key_attributes.rs
@@ -21,8 +21,6 @@ use num::FromPrimitive;
 
 impl From<KeyAttributesProto> for KeyAttributes {
     fn from(attrs: KeyAttributesProto) -> Self {
-        let key_lifetime =
-            FromPrimitive::from_i32(attrs.key_lifetime).expect("Failed to convert key lifetime");
         let key_type = FromPrimitive::from_i32(attrs.key_type).expect("Failed to convert key type");
         let ecc_curve = match attrs.ecc_curve() {
             EccCurve::NoEccCurve => None,
@@ -34,7 +32,6 @@ impl From<KeyAttributesProto> for KeyAttributes {
         let algorithm = attrs.algorithm_proto.expect("Algorithm was empty").into();
 
         KeyAttributes {
-            key_lifetime,
             key_type,
             ecc_curve,
             algorithm,
@@ -52,7 +49,6 @@ impl From<KeyAttributesProto> for KeyAttributes {
 impl From<KeyAttributes> for KeyAttributesProto {
     fn from(attrs: KeyAttributes) -> Self {
         KeyAttributesProto {
-            key_lifetime: attrs.key_lifetime as i32,
             key_type: attrs.key_type as i32,
             ecc_curve: match attrs.ecc_curve {
                 None => 0,
@@ -121,7 +117,6 @@ mod test {
             Some(key_attributes::HashAlgorithm::Sha1),
         );
         let key_attrs = KeyAttributes {
-            key_lifetime: key_attributes::KeyLifetime::Persistent,
             key_type: key_attributes::KeyType::RsaKeypair,
             ecc_curve: Some(key_attributes::EccCurve::Secp160k1),
             algorithm: algo,
@@ -136,10 +131,6 @@ mod test {
 
         let key_attrs_proto: KeyAttributesProto = key_attrs.into();
 
-        assert_eq!(
-            key_attrs_proto.key_lifetime,
-            key_attributes_proto::KeyLifetime::Persistent as i32
-        );
         assert_eq!(
             key_attrs_proto.key_type,
             key_attributes_proto::KeyType::RsaKeypair as i32
@@ -164,7 +155,6 @@ mod test {
             hash_algorithm: key_attributes_proto::HashAlgorithm::Sha1 as i32,
         }));
         let key_attrs_proto = KeyAttributesProto {
-            key_lifetime: key_attributes_proto::KeyLifetime::Persistent as i32,
             key_type: key_attributes_proto::KeyType::RsaKeypair as i32,
             ecc_curve: key_attributes_proto::EccCurve::Secp160k1 as i32,
             algorithm_proto: algo,
@@ -178,10 +168,6 @@ mod test {
         };
 
         let key_attrs: KeyAttributes = key_attrs_proto.into();
-        assert_eq!(
-            key_attrs.key_lifetime,
-            key_attributes::KeyLifetime::Persistent
-        );
         assert_eq!(key_attrs.key_type, key_attributes::KeyType::RsaKeypair);
         assert_eq!(
             key_attrs.ecc_curve,


### PR DESCRIPTION
Removes all key lifetime after parallaxsecond/parsec-operations#2.

This will not compile until version `0.1.1` is made on `parsec-operations` containing the changes.