### PR TITLE
Add PKCS 11 ProviderID enumeration variant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "parsec-interface"
-version = "0.2.1"
-authors = ["Ionut Mihalcea <ionut.mihalcea@arm.com>",
+version = "0.3.0"
+authors = ["Paul Howard <paul.howard@arm.com>",
+           "Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]
 edition = "2018"
 

--- a/src/operations/key_attributes.rs
+++ b/src/operations/key_attributes.rs
@@ -20,8 +20,7 @@ use num_derive::FromPrimitive;
 /// Each variant of the enum contains a main algorithm type (which is required for
 /// that variant), as well as configuration fields as allowed by each algorithm in
 /// part.
-#[derive(Debug, Clone)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Clone, PartialEq)]
 pub enum AlgorithmInner {
     Cipher(CipherAlgorithm),
     AsymmetricEncryption(AsymmetricEncryptionAlgorithm, Option<HashAlgorithm>),
@@ -39,7 +38,7 @@ pub enum AlgorithmInner {
 
 /// Wrapper around `AlgorithmInner`, used to statically ensure that any algorithm used
 /// in `KeyAttributes` is a valid combination of algorithms and options.
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct Algorithm(AlgorithmInner);
 
 impl Algorithm {
@@ -111,8 +110,7 @@ pub struct KeyAttributes {
 }
 
 /// Enumeration of key types supported.
-#[derive(FromPrimitive, Copy, Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(FromPrimitive, Copy, Clone, Debug, PartialEq)]
 #[repr(i32)]
 pub enum KeyType {
     HmacKey = 0,
@@ -133,8 +131,7 @@ pub enum KeyType {
 ///
 /// Should only be used for keys with `key_type` either `EccPublicKey`
 /// or `EccKeypair`.
-#[derive(FromPrimitive, Copy, Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(FromPrimitive, Copy, Clone, Debug, PartialEq)]
 #[repr(i32)]
 pub enum EccCurve {
     Sect163k1 = 1,
@@ -173,8 +170,7 @@ pub enum EccCurve {
 ///
 /// Includes both specific algorithms (ARC4) and modes of operation
 /// for algorithms defined through the key type (e.g. `AesKey`).
-#[derive(FromPrimitive, Copy, Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(FromPrimitive, Copy, Clone, Debug, PartialEq)]
 #[repr(i32)]
 pub enum CipherAlgorithm {
     Arc4 = 0,
@@ -187,8 +183,7 @@ pub enum CipherAlgorithm {
 }
 
 /// Enumeration of asymmetric encryption algorithms supported.
-#[derive(FromPrimitive, Copy, Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(FromPrimitive, Copy, Clone, Debug, PartialEq)]
 #[repr(i32)]
 pub enum AsymmetricEncryptionAlgorithm {
     RsaPkcs1v15Crypt = 0,
@@ -196,8 +191,7 @@ pub enum AsymmetricEncryptionAlgorithm {
 }
 
 /// Enumeration of message authentication code algorithms supported.
-#[derive(FromPrimitive, Copy, Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(FromPrimitive, Copy, Clone, Debug, PartialEq)]
 #[repr(i32)]
 pub enum MacAlgorithm {
     Hmac = 0,
@@ -208,8 +202,7 @@ pub enum MacAlgorithm {
 
 /// Enumeration of authenticated encryption with additional data algorithms
 /// supported.
-#[derive(FromPrimitive, Copy, Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(FromPrimitive, Copy, Clone, Debug, PartialEq)]
 #[repr(i32)]
 pub enum AeadAlgorithm {
     Ccm = 0,
@@ -217,8 +210,7 @@ pub enum AeadAlgorithm {
 }
 
 /// Enumeration of asymmetric signing algorithms supported.
-#[derive(FromPrimitive, Copy, Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(FromPrimitive, Copy, Clone, Debug, PartialEq)]
 #[repr(i32)]
 pub enum SignAlgorithm {
     RsaPkcs1v15Sign = 0,
@@ -230,8 +222,7 @@ pub enum SignAlgorithm {
 }
 
 /// Enumeration of key agreement algorithms supported.
-#[derive(FromPrimitive, Copy, Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(FromPrimitive, Copy, Clone, Debug, PartialEq)]
 #[repr(i32)]
 pub enum KeyAgreementAlgorithm {
     Ffdh = 0,
@@ -239,8 +230,7 @@ pub enum KeyAgreementAlgorithm {
 }
 
 /// Enumeration of hash algorithms supported.
-#[derive(FromPrimitive, Copy, Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(FromPrimitive, Copy, Clone, Debug, PartialEq)]
 #[repr(i32)]
 pub enum HashAlgorithm {
     Md2 = 1,
@@ -261,8 +251,7 @@ pub enum HashAlgorithm {
 }
 
 /// Enumeration of key derivation functions supported.
-#[derive(FromPrimitive, Copy, Clone, Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(FromPrimitive, Copy, Clone, Debug, PartialEq)]
 #[repr(i32)]
 pub enum KeyDerivationFunction {
     Hkdf = 0,

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -40,6 +40,8 @@ pub enum ProviderID {
     CoreProvider = 0,
     /// Provider using Mbed Crypto software library.
     MbedProvider = 1,
+    /// Provider using a PKCS 11 compatible library.
+    Pkcs11Provider = 2,
 }
 
 impl std::fmt::Display for ProviderID {


### PR DESCRIPTION
Also remove the "test" config out of PartialEq derive for the key
attributes struct as those will be used in the PKCS 11 provider for
comparison.
Bump the version so that it can be used in other repos.