### PR TITLE
Add TPM Provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parsec-interface"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Paul Howard <paul.howard@arm.com>",
            "Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -42,6 +42,8 @@ pub enum ProviderID {
     MbedProvider = 1,
     /// Provider using a PKCS 11 compatible library.
     Pkcs11Provider = 2,
+    /// Provider using a TSS 2.0 Enhanced System API library.
+    TpmProvider = 3,
 }
 
 impl std::fmt::Display for ProviderID {


### PR DESCRIPTION
Add a new ProdiverID which is the TPM Provider, using the TSS 2.0 ESAPI.
Also bumps the version.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>