### PR TITLE
Remove most panicking behaviour

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ num = "0.2.0"
 prost = "0.5.0"
 bytes = "0.4.12"
 uuid = "0.7.4"
+log = "0.4.8"
 
 [features]
 testing = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parsec-interface"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Paul Howard <paul.howard@arm.com>",
            "Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This project uses the following third party crates:
 * bytes (MIT)
 * num (MIT and Apache-2.0)
 * uuid (Apache-2.0)
+* log (MIT and Apache-2.0)
 
 # Contributing
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,6 @@
     private_in_public,
     safe_extern_statics,
     unconditional_recursion,
-    unions_with_drop_fields,
     unused,
     unused_allocation,
     unused_comparisons,

--- a/src/operations_protobuf/convert_create_key.rs
+++ b/src/operations_protobuf/convert_create_key.rs
@@ -15,7 +15,7 @@
 use super::generated_ops::create_key::{OpCreateKeyProto, ResultCreateKeyProto};
 use crate::operations;
 use crate::requests::ResponseStatus;
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 
 impl TryFrom<OpCreateKeyProto> for operations::OpCreateKey {
     type Error = ResponseStatus;
@@ -28,7 +28,7 @@ impl TryFrom<OpCreateKeyProto> for operations::OpCreateKey {
 
         Ok(operations::OpCreateKey {
             key_name: proto_op.key_name,
-            key_attributes: key_attributes.into(),
+            key_attributes: key_attributes.try_into()?,
         })
     }
 }
@@ -39,7 +39,7 @@ impl TryFrom<operations::OpCreateKey> for OpCreateKeyProto {
     fn try_from(op: operations::OpCreateKey) -> Result<Self, Self::Error> {
         let mut proto: OpCreateKeyProto = Default::default();
         proto.key_name = op.key_name;
-        proto.key_attributes = Some(op.key_attributes.into());
+        proto.key_attributes = Some(op.key_attributes.try_into()?);
 
         Ok(proto)
     }

--- a/src/operations_protobuf/convert_import_key.rs
+++ b/src/operations_protobuf/convert_import_key.rs
@@ -15,7 +15,7 @@
 use super::generated_ops::import_key::{OpImportKeyProto, ResultImportKeyProto};
 use crate::operations;
 use crate::requests::ResponseStatus;
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 
 impl TryFrom<OpImportKeyProto> for operations::OpImportKey {
     type Error = ResponseStatus;
@@ -28,7 +28,7 @@ impl TryFrom<OpImportKeyProto> for operations::OpImportKey {
 
         Ok(operations::OpImportKey {
             key_name: proto_op.key_name,
-            key_attributes: key_attributes.into(),
+            key_attributes: key_attributes.try_into()?,
             key_data: proto_op.key_data,
         })
     }
@@ -40,7 +40,7 @@ impl TryFrom<operations::OpImportKey> for OpImportKeyProto {
     fn try_from(op: operations::OpImportKey) -> Result<Self, Self::Error> {
         Ok(OpImportKeyProto {
             key_name: op.key_name,
-            key_attributes: Some(op.key_attributes.into()),
+            key_attributes: Some(op.key_attributes.try_into()?),
             key_data: op.key_data,
         })
     }


### PR DESCRIPTION
The following functions/macros were replaced by returning errors:
* unwrap
* panic
* expect
* unimplemented
* unreachable

Those should only be allowed in tests and were kept for the env::var
function.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>