### PR TITLE
Derive Arbitrary for fuzz testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parsec-interface"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Paul Howard <paul.howard@arm.com>",
            "Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]
@@ -17,8 +17,10 @@ num-derive = "0.2"
 num = "0.2.0"
 prost = "0.5.0"
 bytes = "0.4.12"
+arbitrary = { version = "0.4.0", features = ["derive"] }
 uuid = "0.7.4"
 log = "0.4.8"
 
 [features]
 testing = []
+fuzz = []

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This project uses the following third party crates:
 * num (MIT and Apache-2.0)
 * uuid (Apache-2.0)
 * log (MIT and Apache-2.0)
+* arbitrary (MIT and Apache-2.0)
 
 # Contributing
 

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -23,6 +23,8 @@ mod response_status;
 pub mod utils;
 pub mod request;
 pub mod response;
+#[cfg(feature = "fuzz")]
+use arbitrary::Arbitrary;
 pub use request::Request;
 pub use response::Response;
 pub use response_status::{ResponseStatus, Result};
@@ -33,6 +35,7 @@ const MAGIC_NUMBER: u32 = 0x5EC0_A710;
 /// Listing of provider types and their associated codes.
 ///
 /// Passed in headers as `provider`.
+#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 #[derive(FromPrimitive, PartialEq, Eq, Hash, Copy, Clone, Debug)]
 #[repr(u8)]
 pub enum ProviderID {
@@ -66,6 +69,7 @@ impl TryFrom<u8> for ProviderID {
 /// Listing of body encoding types and their associated codes.
 ///
 /// Passed in headers as `content_type` and `accept_type`.
+#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 #[derive(FromPrimitive, Copy, Clone, Debug, PartialEq)]
 #[repr(u8)]
 pub enum BodyType {
@@ -78,6 +82,7 @@ pub enum BodyType {
 /// Passed in headers as `opcode`. The values of the enumeration constants come from the operations
 /// documentation available
 /// [here](https://github.com/docker/parsec/blob/master/docs/operation_directory.proto).
+#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 #[derive(FromPrimitive, Copy, Clone, PartialEq, Debug, Hash, Eq)]
 #[repr(u16)]
 pub enum Opcode {
@@ -95,6 +100,7 @@ pub enum Opcode {
 /// Listing of available authentication methods.
 ///
 /// Passed in headers as `auth_type`.
+#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 #[derive(FromPrimitive, PartialEq, Eq, Hash, Copy, Clone, Debug)]
 #[repr(u8)]
 pub enum AuthType {

--- a/src/requests/request/mod.rs
+++ b/src/requests/request/mod.rs
@@ -14,6 +14,8 @@
 // limitations under the License.
 use super::response::ResponseHeader;
 use crate::requests::{ResponseStatus, Result};
+#[cfg(feature = "fuzz")]
+use arbitrary::Arbitrary;
 use request_header::RawRequestHeader;
 use std::convert::{TryFrom, TryInto};
 use std::io::{Read, Write};
@@ -39,6 +41,7 @@ pub use request_header::RawRequestHeader as RawHeader;
 ///
 /// Auth field is stored as a `RequestAuth` object. A parser that can handle the `auth_type`
 /// specified in the header is needed to authenticate the request.
+#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 #[derive(PartialEq, Debug)]
 pub struct Request {
     pub header: RequestHeader,

--- a/src/requests/request/request_auth.rs
+++ b/src/requests/request/request_auth.rs
@@ -13,11 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::requests::Result;
+#[cfg(feature = "fuzz")]
+use arbitrary::Arbitrary;
 use std::io::{Read, Write};
 
 /// Wrapper around the body of a request.
 ///
 /// Hides the contents and keeps them immutable.
+#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct RequestAuth {
     bytes: Vec<u8>,

--- a/src/requests/request/request_body.rs
+++ b/src/requests/request/request_body.rs
@@ -13,11 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use crate::requests::Result;
+#[cfg(feature = "fuzz")]
+use arbitrary::Arbitrary;
 use std::io::{Read, Write};
 
 /// Wrapper around the body of a request.
 ///
 /// Hides the contents and keeps them immutable.
+#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 #[derive(Debug, PartialEq)]
 pub struct RequestBody {
     bytes: Vec<u8>,

--- a/src/requests/request/request_header.rs
+++ b/src/requests/request/request_header.rs
@@ -16,6 +16,8 @@ use super::REQUEST_HDR_SIZE;
 use crate::requests::MAGIC_NUMBER;
 use crate::requests::{AuthType, BodyType, Opcode, ProviderID};
 use crate::requests::{ResponseStatus, Result};
+#[cfg(feature = "fuzz")]
+use arbitrary::Arbitrary;
 use num::FromPrimitive;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
@@ -25,6 +27,7 @@ use std::io::{Read, Write};
 ///
 /// Serialisation and deserialisation are handled by `serde`, also in tune with the
 /// wire format (i.e. little-endian, native encoding).
+#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub struct RawRequestHeader {
     pub version_maj: u8,
@@ -101,6 +104,7 @@ impl RawRequestHeader {
 ///
 /// Fields that are not relevant for application development (e.g. magic number) are
 /// not copied across from the raw header.
+#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct RequestHeader {
     pub version_maj: u8,


### PR DESCRIPTION
This commits adds conditional derivation of the Arbitrary trait for the structures
and enums that require it for implementing fuzz testing.