### PR TITLE
Add body length limit to reading requests and responses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parsec-interface"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Paul Howard <paul.howard@arm.com>",
            "Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,9 +69,11 @@
 //!use parsec_interface::operations_protobuf::ProtobufConverter;
 //!use parsec_interface::operations::ResultCreateKey;
 //!
+//!const MAX_BODY_LENGTH: usize = 2048;
+//!
 //!let mut stream = UnixStream::connect("socket_path").unwrap();
 //!let converter = ProtobufConverter {};
-//!let request = Request::read_from_stream(&mut stream).unwrap();
+//!let request = Request::read_from_stream(&mut stream, MAX_BODY_LENGTH).unwrap();
 //!let operation = converter.body_to_operation(request.body, request.header.opcode).unwrap();
 //!
 //!// Deal with the operation to get a `NativeResult`
@@ -108,6 +110,8 @@
 //!use parsec_interface::operations_protobuf::ProtobufConverter;
 //!use parsec_interface::operations::OpPing;
 //!
+//!const MAX_BODY_LENGTH: usize = 2048;
+//!
 //!let mut stream = UnixStream::connect("socket_path").unwrap();
 //!let converter = ProtobufConverter {};
 //!let operation = NativeOperation::Ping(OpPing {});
@@ -128,7 +132,7 @@
 //!request.write_to_stream(&mut stream).unwrap();
 //!
 //!// Wait for the service to execute the operation
-//!let response = Response::read_from_stream(&mut stream).unwrap();
+//!let response = Response::read_from_stream(&mut stream, MAX_BODY_LENGTH).unwrap();
 //!let result = converter.body_to_result(response.body, response.header.opcode).unwrap();
 //!```
 

--- a/src/requests/response_status.rs
+++ b/src/requests/response_status.rs
@@ -47,6 +47,7 @@ pub enum ResponseStatus {
     WrongProviderUuid = 22,
     NotAuthenticated = 23,
     UnsupportedParameters = 24,
+    BodySizeExceedsLimit = 25,
     PsaErrorGenericError = 1132,
     PsaErrorNotPermitted = 1133,
     PsaErrorNotSupported = 1134,
@@ -154,6 +155,9 @@ impl fmt::Display for ResponseStatus {
             }
             ResponseStatus::UnsupportedParameters => {
                 write!(f, "requested parameters are not supported by the provider")
+            }
+            ResponseStatus::BodySizeExceedsLimit => {
+                write!(f, "request length specified in the header is above defined limit")
             }
             ResponseStatus::PsaErrorGenericError => {
                 write!(f, "an error occurred that does not correspond to any defined failure cause")


### PR DESCRIPTION
This commit adds a parameter to the `read_from_stream` methods for
requests and responses, which acts as a hard limit on the size of the
request/response body. This is to allow clients to protect themselves
from running out of memory when processing requests/responses.