### PR TITLE
Various lint fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - run: cargo clippy
+    - run: cargo clippy --all-targets --all-features -- -D clippy::all -D clippy::cargo
 
   cross-testing-arm64-linux:
     name: Cross testing for the aarch64-unknown-linux-gnu target

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@
 --->
 # Contributing to `parsec-interface-rs`
 
-Contributions to PARSEC need to follow the process below.
+Contributions to Parsec need to follow the process below.
 
 * Contributions are done through GitHub pull-requests.
 * Contributors need to apply `rustfmt` and `clippy` to their Rust code.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,12 @@ version = "0.6.0"
 authors = ["Paul Howard <paul.howard@arm.com>",
            "Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]
+description = "Parsec interface library to communicate using the wire protocol"
+license = "Apache-2.0"
+repository = "https://github.com/parallaxsecond/parsec-interface-rs"
+readme = "README.md"
+keywords = ["parsec", "interface", "serialization"]
+categories = ["encoding"]
 edition = "2018"
 
 [build-dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This Dockerfile is used by cross for cross-compilation and cross-testing of
-# PARSEC.
+# Parsec.
 
 FROM rustembedded/cross:aarch64-unknown-linux-gnu-0.1.16
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,14 +43,16 @@
     unused_results,
     missing_copy_implementations
 )]
-//! # PARSEC Rust Interface
+// This one is hard to avoid.
+#![allow(clippy::multiple_crate_versions)]
+//! # Parsec Rust Interface
 //!
-//! The PARSEC Rust Interface provides methods to communicate easily with the PARSEC service using
+//! The Parsec Rust Interface provides methods to communicate easily with the Parsec service using
 //! the [wire protocol](https://github.com/docker/parsec/blob/master/docs/wire_protocol.md).
 //!
-//! ## For the PARSEC service
+//! ## For the Parsec service
 //!
-//! This library is used by the PARSEC service to:
+//! This library is used by the Parsec service to:
 //! * read from a stream a `Request` sent to the service with the `read_from_stream` method
 //! * use the `body_to_operation` method of the `Convert` trait on a converter to parse the request
 //! body into a `NativeOperation`
@@ -86,18 +88,18 @@
 //!response.write_to_stream(&mut stream).unwrap();
 //!```
 //!
-//! ## For the PARSEC Rust clients
+//! ## For the Parsec Rust clients
 //!
-//! This library is used by the PARSEC Rust clients to:
+//! This library is used by the Parsec Rust clients to:
 //! * use the `operation_to_body` method to serialize the `NativeOperation` to be sent as body of a
 //! `Request`
 //! * write it to the stream with the `write_to_stream` method.
 //!
-//! and after the operation has been executed by the PARSEC service:
+//! and after the operation has been executed by the Parsec service:
 //! * read from a stream the `Response` from the service with the `read_from_stream` method
 //! * use the `body_to_result` method to parse the result body into a `NativeResult`
 //!
-//! See the [PARSEC Test client](https://github.com/docker/parsec-client-test) as an example of a
+//! See the [Parsec Test client](https://github.com/docker/parsec-client-test) as an example of a
 //! Rust client.
 //!
 //! ### Example

--- a/src/operations_protobuf/convert_create_key.rs
+++ b/src/operations_protobuf/convert_create_key.rs
@@ -115,7 +115,7 @@ mod test {
     fn create_key_op_e2e() {
         let name = "test name".to_string();
         let op = OpCreateKey {
-            key_name: name.clone(),
+            key_name: name,
             key_attributes: get_key_attrs(),
         };
 

--- a/src/operations_protobuf/convert_import_key.rs
+++ b/src/operations_protobuf/convert_import_key.rs
@@ -122,7 +122,7 @@ mod test {
     fn import_key_op_e2e() {
         let name = "test name".to_string();
         let op = OpImportKey {
-            key_name: name.clone(),
+            key_name: name,
             key_attributes: get_key_attrs(),
             key_data: vec![0x11, 0x22, 0x33],
         };

--- a/src/operations_protobuf/convert_list_opcodes.rs
+++ b/src/operations_protobuf/convert_list_opcodes.rs
@@ -113,7 +113,7 @@ mod test {
         let body = CONVERTER
             .operation_to_body(NativeOperation::ListOpcodes(list_opcodes))
             .expect("Failed to convert request");
-        assert!(body.len() == 0);
+        assert!(body.is_empty());
     }
 
     #[test]

--- a/src/operations_protobuf/convert_list_providers.rs
+++ b/src/operations_protobuf/convert_list_providers.rs
@@ -193,7 +193,7 @@ mod test {
         let body = CONVERTER
             .operation_to_body(NativeOperation::ListProviders(list_providers))
             .expect("Failed to convert request");
-        assert!(body.len() == 0);
+        assert!(body.is_empty());
     }
 
     #[test]

--- a/src/operations_protobuf/convert_ping.rs
+++ b/src/operations_protobuf/convert_ping.rs
@@ -85,9 +85,9 @@ mod test {
             supp_version_min: 1,
         };
 
-        let proto: ResultPing = resp.into();
-        assert!(proto.supp_version_maj == 1);
-        assert!(proto.supp_version_min == 1);
+        let proto: ResultPingProto = resp.try_into().unwrap();
+        assert!(proto.supported_version_maj == 1);
+        assert!(proto.supported_version_min == 1);
     }
 
     #[test]
@@ -102,7 +102,7 @@ mod test {
         let body = CONVERTER
             .operation_to_body(NativeOperation::Ping(ping))
             .expect("Failed to convert request");
-        assert!(body.len() == 0);
+        assert!(body.is_empty());
     }
 
     #[test]

--- a/src/operations_protobuf/mod.rs
+++ b/src/operations_protobuf/mod.rs
@@ -27,7 +27,7 @@ mod convert_list_providers;
 mod convert_list_opcodes;
 
 #[rustfmt::skip]
-#[allow(unused_qualifications, missing_copy_implementations)]
+#[allow(unused_qualifications, missing_copy_implementations, clippy::pedantic)]
 mod generated_ops {
     // Include the Rust generated file in its own module.
     macro_rules! include_protobuf_as_module {

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -39,7 +39,7 @@ const MAGIC_NUMBER: u32 = 0x5EC0_A710;
 #[derive(FromPrimitive, PartialEq, Eq, Hash, Copy, Clone, Debug)]
 #[repr(u8)]
 pub enum ProviderID {
-    /// Provider to use for core PARSEC operations.
+    /// Provider to use for core Parsec operations.
     CoreProvider = 0,
     /// Provider using Mbed Crypto software library.
     MbedProvider = 1,

--- a/src/requests/request/request_header.rs
+++ b/src/requests/request/request_header.rs
@@ -93,7 +93,7 @@ impl RawRequestHeader {
         if magic_number != MAGIC_NUMBER || hdr_size != REQUEST_HDR_SIZE {
             return Err(ResponseStatus::InvalidHeader);
         }
-        let mut bytes = vec![0u8; usize::try_from(hdr_size)?];
+        let mut bytes = vec![0_u8; usize::try_from(hdr_size)?];
         stream.read_exact(&mut bytes)?;
 
         Ok(bincode::deserialize(&bytes)?)

--- a/src/requests/response/response_header.rs
+++ b/src/requests/response/response_header.rs
@@ -86,7 +86,7 @@ impl RawResponseHeader {
         if magic_number != MAGIC_NUMBER || hdr_size != RESPONSE_HDR_SIZE {
             return Err(ResponseStatus::InvalidHeader);
         }
-        let mut bytes = vec![0u8; usize::try_from(hdr_size)?];
+        let mut bytes = vec![0_u8; usize::try_from(hdr_size)?];
         stream.read_exact(&mut bytes)?;
 
         Ok(bincode::deserialize(&bytes)?)

--- a/src/requests/utils.rs
+++ b/src/requests/utils.rs
@@ -17,7 +17,7 @@ macro_rules! get_from_stream {
     ($stream:expr, $type:ty) => {
         match &mut $stream {
             stream => {
-                let mut read_bytes = [0u8; std::mem::size_of::<$type>()];
+                let mut read_bytes = [0_u8; std::mem::size_of::<$type>()];
                 stream.read_exact(&mut read_bytes)?;
                 <$type>::from_le_bytes(read_bytes)
             }


### PR DESCRIPTION
Replaces the clippy command with the one discussed in parallaxsecond/parsec#91. The
pedantic group will be discussed later.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>