### PR TITLE
Replace cross tests for native tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,38 +8,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Build
-      run: cargo build --verbose
-      # rustfmt will check if the code build before checking the formatting.
-      # Because the build script generated a new module in the code,
-      # building the code before checking it is needed.
-    - name: Check formatting
-      run: cargo fmt --all -- --check
-
-  test:
-    name: Run tests
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - run: cargo test --verbose
-
-  linting:
-    name: Execute clippy
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - run: cargo clippy --all-targets --all-features -- -D clippy::all -D clippy::cargo
-
-  cross-testing-arm64-linux:
-    name: Cross testing for the aarch64-unknown-linux-gnu target
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: Install cross
-      run: cargo install cross
-    - name: Build the cross Dockerfile
-      run: docker build -t parsec-cross .
-    - name: Cross-compile with cross
-      run: cross build --target aarch64-unknown-linux-gnu --verbose
-    - name: Execute the unit tests with cross
-      run: cross test --target aarch64-unknown-linux-gnu --verbose
+    - name: Execute all tests
+      run: ./tests/ci.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+# Executing our tests on Arm64 with Travis CI
+arch: arm64
+language: rust
+script:
+- ./tests/ci.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parsec-interface"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Paul Howard <paul.howard@arm.com>",
            "Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]
@@ -14,6 +14,9 @@ edition = "2018"
 
 [build-dependencies]
 prost-build = "0.5.0"
+curl = "0.4.25"
+flate2 = "1.0.13"
+tar = "0.4.26"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,4 +1,0 @@
-# cross configuration file to use the Dockerfile
-
-[target.aarch64-unknown-linux-gnu]
-image = "parsec-cross"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-# This Dockerfile is used by cross for cross-compilation and cross-testing of
-# Parsec.
-
-FROM rustembedded/cross:aarch64-unknown-linux-gnu-0.1.16
-
-RUN apt-get update && \
-    # wget is needed in the build script to download the operations.
-    apt-get install -y wget

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ This project uses the following third party crates:
 * uuid (Apache-2.0)
 * log (MIT and Apache-2.0)
 * arbitrary (MIT and Apache-2.0)
+* curl (MIT)
+* flate2 (MIT and Apache-2.0)
+* tar (MIT and Apache-2.0)
 
 # Contributing
 

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# ------------------------------------------------------------------------------
+# Copyright (c) 2020, Arm Limited, All Rights Reserved
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Continuous Integration test script, executed by GitHub Actions on x86 and
+# Travis CI on Arm64.
+
+set -euf -o pipefail
+
+##############
+# Build test #
+##############
+RUST_BACKTRACE=1 cargo build
+
+#################
+# Static checks #
+#################
+# On native target clippy or fmt might not be available.
+if cargo fmt -h
+then
+	cargo fmt --all -- --check
+fi
+if cargo clippy -h
+then
+	cargo clippy --all-targets -- -D clippy::all -D clippy::cargo
+fi
+
+############################
+# Unit tests and doc tests #
+############################
+RUST_BACKTRACE=1 cargo test
+
+cargo clean


### PR DESCRIPTION
Uses Travis CI for Arm64 tests. Adds the Travis CI YAML file and also
replace the Command structure in the build script with Rust native
crates.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>

Close #17
Close #12
Close #7 

3 in a row 🔫 