### PR TITLE
Add a submodule for the operations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "parsec-operations"]
+	path = parsec-operations
+	url = https://github.com/parallaxsecond/parsec-operations.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parsec-interface"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Paul Howard <paul.howard@arm.com>",
            "Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]
@@ -14,9 +14,6 @@ edition = "2018"
 
 [build-dependencies]
 prost-build = "0.5.0"
-curl = "0.4.25"
-flate2 = "1.0.13"
-tar = "0.4.26"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,16 @@
 This repository contains an interface library to be used both by the Parsec service and a Rust Client library.
 The library contains methods to communicate using the [wire protocol](https://github.com/parallaxsecond/parsec/blob/master/docs/wire_protocol.md).
 
-# License
+## Build
+
+The Parsec operations repository is included as a submodule. Make sure to update it first before
+trying to compile otherwise it will not work ("`No such file or directory`").
+
+```bash
+$ git submodule update --init
+```
+
+## License
 
 The software is provided under Apache-2.0. Contributions to this project are accepted under the same license.
 
@@ -38,11 +47,8 @@ This project uses the following third party crates:
 * uuid (Apache-2.0)
 * log (MIT and Apache-2.0)
 * arbitrary (MIT and Apache-2.0)
-* curl (MIT)
-* flate2 (MIT and Apache-2.0)
-* tar (MIT and Apache-2.0)
 
-# Contributing
+## Contributing
 
 Please check the [Contributing](CONTRIBUTING.md) to know more about the contribution process.
 

--- a/build.rs
+++ b/build.rs
@@ -12,22 +12,12 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use curl::easy::Easy;
-use flate2::read::GzDecoder;
-use std::env;
-use std::fs::{read_dir, File};
-use std::io::{Error, ErrorKind, Result, Write};
+use std::fs::read_dir;
+use std::io::{Error, ErrorKind, Result};
 use std::path::Path;
-use tar::Archive;
-
-const PARSEC_OPERATIONS_VERSION: &str = "0.2.0";
 
 fn generate_proto_sources() -> Result<()> {
-    let path = format!(
-        "{}/parsec-operations-{}/protobuf",
-        env::var("OUT_DIR").unwrap(),
-        PARSEC_OPERATIONS_VERSION
-    );
+    let path = String::from("parsec-operations/protobuf");
     let dir_entries = read_dir(Path::new(&path))?;
     let files: Result<Vec<String>> = dir_entries
         .map(|protos_file| {
@@ -52,41 +42,6 @@ fn generate_proto_sources() -> Result<()> {
     prost_build::compile_protos(&files_slices, &[&path])
 }
 
-fn get_protobuf_files() -> Result<()> {
-    // TODO: Use semantic versioning to get the newest versions.
-    let protobuf_archive_url = format!(
-        "https://codeload.github.com/parallaxsecond/parsec-operations/tar.gz/{}",
-        PARSEC_OPERATIONS_VERSION
-    );
-    let out_dir = env::var("OUT_DIR").unwrap();
-    let protobuf_archive_path = format!("{}/{}.tar.gz", out_dir, PARSEC_OPERATIONS_VERSION);
-    let mut protobuf_archive = File::create(&protobuf_archive_path)?;
-
-    let mut buf = Vec::new();
-    let mut handle = Easy::new();
-    handle.url(&protobuf_archive_url)?;
-    {
-        let mut transfer = handle.transfer();
-        transfer.write_function(|data| {
-            buf.extend_from_slice(data);
-            Ok(data.len())
-        })?;
-        transfer.perform()?;
-    }
-
-    protobuf_archive.write_all(&buf)?;
-
-    // Drop and open the archive again so that GzDecoder sees it as a new file.
-    let protobuf_archive = File::open(&protobuf_archive_path)?;
-
-    let tar = GzDecoder::new(protobuf_archive);
-    let mut archive = Archive::new(tar);
-    archive.unpack(&out_dir)?;
-
-    Ok(())
-}
-
 fn main() -> Result<()> {
-    get_protobuf_files()?;
     generate_proto_sources()
 }

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -22,6 +22,10 @@
 
 set -euf -o pipefail
 
+# The Parsec operations repository is included as a submodule. It is
+# necessary to update it first.
+git submodule update --init
+
 ##############
 # Build test #
 ##############


### PR DESCRIPTION
This commit modifies the build process to directly use the git submodule
containing the protobuf files instead of downloading them from the
GitHub repository. This should allow us to publish the crate without
having it needing internet connection.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>