### PR TITLE
Add a wire protocol version check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parsec-interface"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Paul Howard <paul.howard@arm.com>",
            "Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]

--- a/src/requests/response/mod.rs
+++ b/src/requests/response/mod.rs
@@ -177,11 +177,30 @@ mod tests {
             .expect("Failed to write response");
     }
 
+    #[test]
+    fn wrong_version() {
+        let mut mock = test_utils::MockReadWrite {
+            buffer: get_response_bytes(),
+        };
+        // Put an invalid version major field.
+        mock.buffer[6] = 0xFF;
+        // Put an invalid version minor field.
+        mock.buffer[7] = 0xFF;
+
+        let response_status =
+            Response::read_from_stream(&mut mock, 1000).expect_err("Should have failed.");
+
+        assert_eq!(
+            response_status,
+            ResponseStatus::WireProtocolVersionNotSupported
+        );
+    }
+
     fn get_response() -> Response {
         let body = ResponseBody::from_bytes(vec![0x70, 0x80, 0x90]);
         let header = ResponseHeader {
-            version_maj: 0xde,
-            version_min: 0xf0,
+            version_maj: 0x00,
+            version_min: 0x01,
             provider: ProviderID::CoreProvider,
             session: 0x11_22_33_44_55_66_77_88,
             content_type: BodyType::Protobuf,
@@ -193,7 +212,7 @@ mod tests {
 
     fn get_response_bytes() -> Vec<u8> {
         vec![
-            0x10, 0xA7, 0xC0, 0x5E, 0x14, 0x00, 0xde, 0xf0, 0x00, 0x88, 0x77, 0x66, 0x55, 0x44,
+            0x10, 0xA7, 0xC0, 0x5E, 0x14, 0x00, 0x00, 0x01, 0x00, 0x88, 0x77, 0x66, 0x55, 0x44,
             0x33, 0x22, 0x11, 0x00, 0x03, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x70, 0x80,
             0x90,
         ]

--- a/src/requests/response_status.rs
+++ b/src/requests/response_status.rs
@@ -26,7 +26,7 @@ pub enum ResponseStatus {
     WrongProviderID = 1,
     ContentTypeNotSupported = 2,
     AcceptTypeNotSupported = 3,
-    VersionTooBig = 4,
+    WireProtocolVersionNotSupported = 4,
     ProviderNotRegistered = 5,
     ProviderDoesNotExist = 6,
     DeserializingBodyFailed = 7,
@@ -92,7 +92,7 @@ impl fmt::Display for ResponseStatus {
             ResponseStatus::AcceptTypeNotSupported => {
                 write!(f, "requested accept type is not supported by the backend")
             }
-            ResponseStatus::VersionTooBig => {
+            ResponseStatus::WireProtocolVersionNotSupported => {
                 write!(f, "requested version is not supported by the backend")
             }
             ResponseStatus::ProviderNotRegistered => {


### PR DESCRIPTION
As per the discussion in parallaxsecond/parsec#105, it was decided that
the version check should happen in the front-end handler. Because there
is currently only one version supported (0.1), and it might stay like
this for a long time, this commit adds a simple check directly in the
request/response parser.
If multiple versions are supported, this would not suffice and a better
solution should be adopted but this is probably fine for now.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>