### PR TITLE
Add code documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,12 @@
 --->
 # Parsec Rust Interface
 
-![](https://github.com/parallaxsecond/parsec-interface-rs/workflows/Continuous%20Integration/badge.svg)
-![](https://travis-ci.com/parallaxsecond/parsec.svg?branch=master)
+<p align="center">
+  <a href="https://crates.io/crates/parsec-interface"><img alt="Crates.io" src="https://img.shields.io/crates/v/parsec-interface"></a>
+  <a href="https://docs.rs/parsec-interface"><img src="https://docs.rs/parsec-interface/badge.svg" alt="Code documentation"/></a>
+  <a href="https://github.com/parallaxsecond/parsec-interface-rs/actions?query=workflow%3A%22Continuous+Integration%22"><img src="https://github.com/parallaxsecond/parsec-interface-rs/workflows/Continuous%20Integration/badge.svg" alt="CI tests"/></a>
+  <a href="https://travis-ci.com/parallaxsecond/parsec-interface-rs"><img src="https://travis-ci.com/parallaxsecond/parsec-interface-rs.svg?branch=master" alt="Travis CI tests"/></a>
+</p>
 
 This repository contains an interface library to be used both by the Parsec service and a Rust Client library.
 The library contains methods to communicate using the [wire protocol](https://github.com/parallaxsecond/parsec/blob/master/docs/wire_protocol.md).

--- a/src/operations/asym_sign.rs
+++ b/src/operations/asym_sign.rs
@@ -14,26 +14,23 @@
 // limitations under the License.
 
 /// Native object for asymmetric sign operations.
-///
-/// `key_name` defines which key should be used for the signing operation.
-/// The `hash` value must either be a short message (length dependend on the size of
-/// the key), or the result of a hashing operation. Thus, if a hash-and-sign is
-/// required, the hash must be computed before this operation is called. The length
-/// of the hash must be equal to the length of the hash specified on the key algorithm.
-///
-/// The `hash` field must also follow any formatting conventions dictated by the provider for
-/// which the request was made.
 #[derive(Debug)]
 pub struct OpAsymSign {
+    /// Defines which key should be used for the signing operation.
     pub key_name: String,
+    /// This value must either be a short message (length dependend on the size of
+    /// the key), or the result of a hashing operation. Thus, if a hash-and-sign is
+    /// required, the hash must be computed before this operation is called. The length
+    /// of the hash must be equal to the length of the hash specified on the key algorithm.
+    /// This field must also follow any formatting conventions dictated by the provider for
+    /// which the request was made.
     pub hash: Vec<u8>,
 }
 
 /// Native object for asymmetric sign result.
-///
-/// The `signature` field contains the resulting bytes from the signing operation. The format of
-/// the signature is as specified by the provider doing the signing.
 #[derive(Debug)]
 pub struct ResultAsymSign {
+    /// The `signature` field contains the resulting bytes from the signing operation. The format of
+    /// the signature is as specified by the provider doing the signing.
     pub signature: Vec<u8>,
 }

--- a/src/operations/asym_verify.rs
+++ b/src/operations/asym_verify.rs
@@ -14,16 +14,15 @@
 // limitations under the License.
 
 /// Native object for asymmetric verification of signatures.
-///
-/// `key_name` specifies the key to be used for verification.
-/// The `hash` contains a short message or hash value as described for the
-/// asymmetric signing operation.
-/// `signature` contains the bytes of the signature which requires validation and must
-/// follow any format requirements imposed by the provider.
 #[derive(Debug)]
 pub struct OpAsymVerify {
+    /// `key_name` specifies the key to be used for verification.
     pub key_name: String,
+    /// The `hash` contains a short message or hash value as described for the
+    /// asymmetric signing operation.
     pub hash: Vec<u8>,
+    /// `signature` contains the bytes of the signature which requires validation and must
+    /// follow any format requirements imposed by the provider.
     pub signature: Vec<u8>,
 }
 

--- a/src/operations/create_key.rs
+++ b/src/operations/create_key.rs
@@ -15,13 +15,12 @@
 use super::key_attributes::KeyAttributes;
 
 /// Native object for creating a cryptographic key.
-///
-/// `key_name` specifies a name by which the service will identify the key. Key
-/// name must be unique per application. `key_attributes` specifies the parameters
-/// to be associated with the key.
 #[derive(Clone, Debug)]
 pub struct OpCreateKey {
+    /// `key_name` specifies a name by which the service will identify the key. Key
+    /// name must be unique per application.
     pub key_name: String,
+    /// `key_attributes` specifies the parameters to be associated with the key.
     pub key_attributes: KeyAttributes,
 }
 

--- a/src/operations/destroy_key.rs
+++ b/src/operations/destroy_key.rs
@@ -14,10 +14,9 @@
 // limitations under the License.
 
 /// Native object for cryptographic key destruction.
-///
-/// `key_name` identifies the key to be destroyed.
 #[derive(Debug, Clone)]
 pub struct OpDestroyKey {
+    /// `key_name` identifies the key to be destroyed.
     pub key_name: String,
 }
 

--- a/src/operations/export_public_key.rs
+++ b/src/operations/export_public_key.rs
@@ -14,19 +14,17 @@
 // limitations under the License.
 
 /// Native object for public key exporting operation.
-///
-/// `key_name` identifies the key for which the public
-/// part will be exported. The specified key must be an asymmetric keypair.
 #[derive(Debug)]
 pub struct OpExportPublicKey {
+    /// `key_name` identifies the key for which the public
+    /// part will be exported. The specified key must be an asymmetric keypair.
     pub key_name: String,
 }
 
 /// Native object for result of public key export operation.
-///
-/// `key_data` holds the bytes defining the public key, formatted as specified
-/// by the provider for which the request was made.
 #[derive(Debug)]
 pub struct ResultExportPublicKey {
+    /// `key_data` holds the bytes defining the public key, formatted as specified
+    /// by the provider for which the request was made.
     pub key_data: Vec<u8>,
 }

--- a/src/operations/import_key.rs
+++ b/src/operations/import_key.rs
@@ -15,16 +15,17 @@
 use super::key_attributes::KeyAttributes;
 
 /// Native object for cryptographic key importing operation.
-///
-/// `key_name` specifies a name by which the service will identify the key. Key
-/// name must be unique per application. `key_attributes` specifies the parameters
-/// to be associated with the key. `key_data` contains the bytes for the key,
-/// formatted in accordance with the requirements of the provider for the key type
-/// specified in `key_attributes`.
 #[derive(Clone, Debug)]
 pub struct OpImportKey {
+    /// `key_name` specifies a name by which the service will identify the key. Key
+    /// name must be unique per application.
     pub key_name: String,
+    /// `key_attributes` specifies the parameters
+    /// to be associated with the key.
     pub key_attributes: KeyAttributes,
+    /// `key_data` contains the bytes for the key,
+    /// formatted in accordance with the requirements of the provider for the key type
+    /// specified in `key_attributes`.
     pub key_data: Vec<u8>,
 }
 

--- a/src/operations/key_attributes.rs
+++ b/src/operations/key_attributes.rs
@@ -12,6 +12,8 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//! Key attributes module
+
 use num_derive::FromPrimitive;
 
 /// Enumeration of possible algorithm definitions that can be attached to

--- a/src/operations/list_opcodes.rs
+++ b/src/operations/list_opcodes.rs
@@ -20,10 +20,9 @@ use std::collections::HashSet;
 pub struct OpListOpcodes;
 
 /// Native object for opcode listing result.
-///
-/// `opcodes` holds a list of opcodes supported by the provider identified in
-/// the request.
 #[derive(Debug)]
 pub struct ResultListOpcodes {
+    /// `opcodes` holds a list of opcodes supported by the provider identified in
+    /// the request.
     pub opcodes: HashSet<Opcode>,
 }

--- a/src/operations/list_providers.rs
+++ b/src/operations/list_providers.rs
@@ -33,10 +33,9 @@ pub struct ProviderInfo {
 pub struct OpListProviders;
 
 /// Native object for provider listing result.
-///
-/// A list of `ProviderInfo` structures, one for each provider available in
-/// the service.
 #[derive(Debug)]
 pub struct ResultListProviders {
+    /// A list of `ProviderInfo` structures, one for each provider available in
+    /// the service.
     pub providers: Vec<ProviderInfo>,
 }

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -14,8 +14,9 @@
 // limitations under the License.
 //! # Rust representation of operations
 //!
-//! `NativeOperation` and `NativeResult`: Rust native representation of the language neutral operations
-//! described in [`parsec-operations`](https://github.com/docker/parsec-operations).
+//! Rust native representation of the language neutral operations described in the
+//! [Operations](https://parallaxsecond.github.io/parsec-book/parsec_client/operations/index.html)
+//! page in the book.
 mod ping;
 pub mod key_attributes;
 mod create_key;

--- a/src/operations/ping.rs
+++ b/src/operations/ping.rs
@@ -19,11 +19,11 @@ pub struct OpPing;
 
 /// Native object for Ping result.
 ///
-/// The field names stand for 'supported version major' and
-/// 'supported version minor' - the latest version supported by the
-/// provider forming the result.
+/// The latest wire protocol version supported by the service.
 #[derive(Copy, Clone, Debug)]
 pub struct ResultPing {
+    /// Supported version major
     pub supp_version_maj: u8,
+    /// Supported version minor
     pub supp_version_min: u8,
 }

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -12,7 +12,7 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//! # `Request`s and `Response`s
+//! # Request and response definitions
 //!
 //! A `Request` is what is sent to the service to execute one operation. A `Response` is what the
 //! service returns.
@@ -79,9 +79,9 @@ pub enum BodyType {
 
 /// Listing of available operations and their associated opcode.
 ///
-/// Passed in headers as `opcode`. The values of the enumeration constants come from the operations
-/// documentation available
-/// [here](https://github.com/docker/parsec/blob/master/docs/operation_directory.proto).
+/// Passed in headers as `opcode`. Check the
+/// [Operations](https://parallaxsecond.github.io/parsec-book/parsec_client/operations/index.html)
+/// page of the book for more information.
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 #[derive(FromPrimitive, Copy, Clone, PartialEq, Debug, Hash, Eq)]
 #[repr(u16)]

--- a/src/requests/request/mod.rs
+++ b/src/requests/request/mod.rs
@@ -12,6 +12,9 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//! # Request definition
+//!
+//! A `Request` is to the service to execute one operation.
 use super::response::ResponseHeader;
 use crate::requests::{ResponseStatus, Result};
 #[cfg(feature = "fuzz")]
@@ -35,18 +38,17 @@ pub use request_header::RequestHeader;
 pub use request_header::RawRequestHeader as RawHeader;
 
 /// Representation of the request wire format.
-///
-/// Request body consists of `RequestBody` object holding a collection of bytes.
-/// Interpretation of said bytes is deferred to the a converter which can handle the
-/// `content_type` defined in the header.
-///
-/// Auth field is stored as a `RequestAuth` object. A parser that can handle the `auth_type`
-/// specified in the header is needed to authenticate the request.
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 #[derive(PartialEq, Debug)]
 pub struct Request {
+    /// Request header
     pub header: RequestHeader,
+    /// Request body consists of `RequestBody` object holding a collection of bytes.
+    /// Interpretation of said bytes is deferred to the a converter which can handle the
+    /// `content_type` defined in the header.
     pub body: RequestBody,
+    /// Auth field is stored as a `RequestAuth` object. A parser that can handle the `auth_type`
+    /// specified in the header is needed to authenticate the request.
     pub auth: RequestAuth,
 }
 
@@ -93,7 +95,7 @@ impl Request {
     /// - if reading any of the subfields (header, body or auth) fails, the corresponding
     /// `ResponseStatus` will be returned.
     /// - if the request body size specified in the header is larger than the limit passed as
-    /// a parameter, `RequestBodyExceedsLimit` will be returned.
+    /// a parameter, `BodySizeExceedsLimit` will be returned.
     pub fn read_from_stream(stream: &mut impl Read, body_len_limit: usize) -> Result<Request> {
         let raw_header = RawRequestHeader::read_from_stream(stream)?;
         let body_len = usize::try_from(raw_header.body_len)?;

--- a/src/requests/request/request_auth.rs
+++ b/src/requests/request/request_auth.rs
@@ -17,7 +17,7 @@ use crate::requests::Result;
 use arbitrary::Arbitrary;
 use std::io::{Read, Write};
 
-/// Wrapper around the body of a request.
+/// Wrapper around the authentication value of a request.
 ///
 /// Hides the contents and keeps them immutable.
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]

--- a/src/requests/request/request_header.rs
+++ b/src/requests/request/request_header.rs
@@ -113,7 +113,9 @@ impl RawRequestHeader {
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct RequestHeader {
+    /// Only 1 is a supported value for that field currently.
     pub version_maj: u8,
+    /// Only 0 is a supported value for that field currently.
     pub version_min: u8,
     pub provider: ProviderID,
     pub session: u64,

--- a/src/requests/response/mod.rs
+++ b/src/requests/response/mod.rs
@@ -12,6 +12,8 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//! Response definition
+
 use super::request::RequestHeader;
 use super::ResponseStatus;
 use super::Result;
@@ -32,13 +34,12 @@ pub use response_header::ResponseHeader;
 pub use response_header::RawResponseHeader as RawHeader;
 
 /// Native representation of the response wire format.
-///
-/// Response body consists of an opaque vector of bytes. Interpretation of said bytes
-/// is deferred to the a converter which can handle the `content_type` defined in the
-/// header.
 #[derive(PartialEq, Debug)]
 pub struct Response {
     pub header: ResponseHeader,
+    /// Response body consists of an opaque vector of bytes. Interpretation of said bytes
+    /// is deferred to the a converter which can handle the `content_type` defined in the
+    /// header.
     pub body: ResponseBody,
 }
 
@@ -63,6 +64,7 @@ impl Response {
         response
     }
 
+    /// Create an empty response with a specific status.
     pub fn from_status(status: ResponseStatus) -> Response {
         let mut response = Response::new();
         response.header.status = status;
@@ -98,7 +100,7 @@ impl Response {
     /// - if reading any of the subfields (header or body) fails, the
     /// corresponding `ResponseStatus` will be returned.
     /// - if the request body size specified in the header is larger than the limit passed as
-    /// a parameter, `RequestBodyExceedsLimit` will be returned.
+    /// a parameter, `BodySizeExceedsLimit` will be returned.
     pub fn read_from_stream(stream: &mut impl Read, body_len_limit: usize) -> Result<Response> {
         let raw_header = RawResponseHeader::read_from_stream(stream)?;
         let body_len = usize::try_from(raw_header.body_len)?;

--- a/src/requests/response/response_header.rs
+++ b/src/requests/response/response_header.rs
@@ -105,7 +105,9 @@ impl RawResponseHeader {
 /// not copied across from the raw header.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct ResponseHeader {
+    /// Only 1 is a supported value for that field currently.
     pub version_maj: u8,
+    /// Only 0 is a supported value for that field currently.
     pub version_min: u8,
     pub provider: ProviderID,
     pub session: u64,

--- a/src/requests/response_status.rs
+++ b/src/requests/response_status.rs
@@ -19,6 +19,10 @@ use std::error::Error as ErrorTrait;
 use std::fmt;
 
 /// C-like enum mapping response status options to their code.
+///
+/// See the [status
+/// code](https://parallaxsecond.github.io/parsec-book/parsec_client/status_codes.html) page for a
+/// broader description of these codes.
 #[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
 #[repr(u16)]
 pub enum ResponseStatus {
@@ -202,6 +206,10 @@ impl fmt::Display for ResponseStatus {
 
 impl ErrorTrait for ResponseStatus {}
 
+/// Conversion from a std::io::Error to a ResponseStatus
+///
+/// It allows to easily return a ResponseStatus in case of error when using functions from the
+/// standard library.
 impl From<std::io::Error> for ResponseStatus {
     fn from(err: std::io::Error) -> Self {
         warn!(
@@ -238,4 +246,5 @@ impl From<std::convert::Infallible> for ResponseStatus {
     }
 }
 
+/// A Result type with the Err variant set as a ResponseStatus
 pub type Result<T> = std::result::Result<T, ResponseStatus>;

--- a/src/requests/utils.rs
+++ b/src/requests/utils.rs
@@ -12,6 +12,7 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//! Module containing helper macros and functions used in tests.
 #![macro_use]
 macro_rules! get_from_stream {
     ($stream:expr, $type:ty) => {


### PR DESCRIPTION
Modifies the root crate documentation examples so that they are all
executable.
Adds more documentation here and there.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>