### PR TITLE
Add body_type fn to Convert

### DIFF
--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -33,7 +33,7 @@ pub mod psa_verify_hash;
 pub mod list_opcodes;
 pub mod list_providers;
 
-use crate::requests::{request::RequestBody, response::ResponseBody, Opcode, Result};
+use crate::requests::{request::RequestBody, response::ResponseBody, BodyType, Opcode, Result};
 
 /// Container type for operation conversion values, holding a native operation object
 /// to be passed in/out of a converter.
@@ -120,6 +120,9 @@ impl NativeResult {
 /// Definition of the operations converters must implement to allow usage of a specific
 /// `BodyType`.
 pub trait Convert {
+    /// Get the `BodyType` associated with this converter.
+    fn body_type(&self) -> BodyType;
+
     /// Create a native operation object from a request body.
     ///
     /// # Errors

--- a/src/operations_protobuf/mod.rs
+++ b/src/operations_protobuf/mod.rs
@@ -55,7 +55,7 @@ mod generated_ops {
 
 use crate::operations::{Convert, NativeOperation, NativeResult};
 use crate::requests::{
-    request::RequestBody, response::ResponseBody, Opcode, ResponseStatus, Result,
+    request::RequestBody, response::ResponseBody, BodyType, Opcode, ResponseStatus, Result,
 };
 use generated_ops::list_opcodes as list_opcodes_proto;
 use generated_ops::list_providers as list_providers_proto;
@@ -96,6 +96,10 @@ macro_rules! native_to_wire {
 pub struct ProtobufConverter;
 
 impl Convert for ProtobufConverter {
+    fn body_type(&self) -> BodyType {
+        BodyType::Protobuf
+    }
+
     fn body_to_operation(&self, body: RequestBody, opcode: Opcode) -> Result<NativeOperation> {
         match opcode {
             Opcode::ListProviders => Ok(NativeOperation::ListProviders(wire_to_native!(


### PR DESCRIPTION
This commit adds a method for obtaining the `BodyType` from implementors
of `Convert`, making it easier to identify them without the need for
external information.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>

Fixes #40 