### PR TITLE
Remove wire protocol version from RequestHeader

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,8 +128,6 @@
 //!let result_body = converter.result_to_body(result).unwrap();
 //!let response = Response {
 //!    header: ResponseHeader {
-//!        version_maj: 1,
-//!        version_min: 0,
 //!        provider: ProviderID::MbedCrypto,
 //!        session: 0,
 //!        content_type: BodyType::Protobuf,
@@ -180,8 +178,6 @@
 //!let operation = NativeOperation::Ping(Operation {});
 //!let request = Request {
 //!    header: RequestHeader {
-//!        version_maj: 1,
-//!        version_min: 0,
 //!        provider: ProviderID::Core,
 //!        session: 0,
 //!        content_type: BodyType::Protobuf,

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -32,6 +32,9 @@ use std::convert::TryFrom;
 
 const MAGIC_NUMBER: u32 = 0x5EC0_A710;
 
+const WIRE_PROTOCOL_VERSION_MAJ: u8 = 1;
+const WIRE_PROTOCOL_VERSION_MIN: u8 = 0;
+
 /// Listing of provider types and their associated codes.
 ///
 /// Passed in headers as `provider`.

--- a/src/requests/request/mod.rs
+++ b/src/requests/request/mod.rs
@@ -23,8 +23,6 @@ use log::error;
 use std::convert::{TryFrom, TryInto};
 use std::io::{Read, Write};
 
-const REQUEST_HDR_SIZE: u16 = 22;
-
 mod request_auth;
 mod request_body;
 mod request_header;
@@ -128,8 +126,6 @@ impl Default for Request {
 impl From<RequestHeader> for ResponseHeader {
     fn from(req_hdr: RequestHeader) -> ResponseHeader {
         ResponseHeader {
-            version_maj: req_hdr.version_maj,
-            version_min: req_hdr.version_min,
             provider: req_hdr.provider,
             session: req_hdr.session,
             content_type: req_hdr.accept_type,
@@ -203,8 +199,6 @@ mod tests {
         let resp_hdr: ResponseHeader = req_hdr.into();
 
         let mut resp_hdr_exp = ResponseHeader::new();
-        resp_hdr_exp.version_maj = 0x01;
-        resp_hdr_exp.version_min = 0x00;
         resp_hdr_exp.provider = ProviderID::Core;
         resp_hdr_exp.session = 0x11_22_33_44_55_66_77_88;
         resp_hdr_exp.content_type = BodyType::Protobuf;
@@ -237,8 +231,6 @@ mod tests {
         let body = RequestBody::from_bytes(vec![0x70, 0x80, 0x90]);
         let auth = RequestAuth::from_bytes(vec![0xa0, 0xb0, 0xc0]);
         let header = RequestHeader {
-            version_maj: 0x01,
-            version_min: 0x00,
             provider: ProviderID::Core,
             session: 0x11_22_33_44_55_66_77_88,
             content_type: BodyType::Protobuf,

--- a/src/requests/response/mod.rs
+++ b/src/requests/response/mod.rs
@@ -201,8 +201,6 @@ mod tests {
     fn get_response() -> Response {
         let body = ResponseBody::from_bytes(vec![0x70, 0x80, 0x90]);
         let header = ResponseHeader {
-            version_maj: 0x01,
-            version_min: 0x00,
             provider: ProviderID::Core,
             session: 0x11_22_33_44_55_66_77_88,
             content_type: BodyType::Protobuf,


### PR DESCRIPTION
This commit removes the wire protocol version fields from the
RequestField structure, leaving it as an inherent property of the
specific RequestHeader implementation.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>