### PR TITLE
Add provider ID to list_opcodes

### DIFF
--- a/src/operations/list_opcodes.rs
+++ b/src/operations/list_opcodes.rs
@@ -16,12 +16,15 @@
 //!
 //! List the opcodes supported by the provider.
 
-use crate::requests::Opcode;
+use crate::requests::{Opcode, ProviderID};
 use std::collections::HashSet;
 
 /// Native object for opcode listing operation.
 #[derive(Copy, Clone, Debug)]
-pub struct Operation;
+pub struct Operation {
+    /// Provider for which the supported opcodes are requsted.
+    pub provider_id: ProviderID,
+}
 
 /// Native object for opcode listing result.
 #[derive(Debug)]


### PR DESCRIPTION
This commit updates the list_opcodes operation to include the ID of the
provider for which the opcodes are requested. This is in line with
previous changes made to the protobuf operations contracts.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>