### PR TITLE
Modify Opcode size

### DIFF
--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -71,7 +71,7 @@ pub enum BodyType {
 /// page of the book for more information.
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 #[derive(FromPrimitive, Copy, Clone, PartialEq, Debug, Hash, Eq)]
-#[repr(u16)]
+#[repr(u32)]
 pub enum Opcode {
     /// Ping operation
     Ping = 1,


### PR DESCRIPTION
The opcode field is now 32-bit long. Fix #49

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>