### PR TITLE
Add validation to sign and verify operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parsec-interface"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["Paul Howard <paul.howard@arm.com>",
            "Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]

--- a/src/operations/psa_sign_hash.rs
+++ b/src/operations/psa_sign_hash.rs
@@ -4,7 +4,9 @@
 //!
 //! Sign an already-calculated hash with a private key.
 
+use super::psa_key_attributes::KeyAttributes;
 use crate::operations::psa_algorithm::AsymmetricSignature;
+use crate::requests::ResponseStatus;
 
 /// Native object for asymmetric sign operations.
 #[derive(Debug)]
@@ -24,4 +26,136 @@ pub struct Result {
     /// The `signature` field contains the resulting bytes from the signing operation. The format of
     /// the signature is as specified by the provider doing the signing.
     pub signature: Vec<u8>,
+}
+
+impl Operation {
+    /// Validate the contents of the operation against the attributes of the key it targets
+    ///
+    /// This method checks that:
+    /// * the key policy allows signing hashes
+    /// * the key policy allows the signing algorithm requested in the operation
+    /// * the key type is compatible with the requested algorithm
+    /// * the length of the given digest is consistent with the specified signing algorithm
+    pub fn validate(&self, key_attributes: KeyAttributes) -> crate::requests::Result<()> {
+        key_attributes.can_sign_hash()?;
+        key_attributes.permits_alg(self.alg.into())?;
+        key_attributes.compatible_with_alg(self.alg.into())?;
+        if !self.alg.is_hash_len_permitted(self.hash.len()) {
+            return Err(ResponseStatus::PsaErrorInvalidArgument);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::operations::psa_algorithm::{Algorithm, AsymmetricSignature, Hash};
+    use crate::operations::psa_key_attributes::{EccFamily, KeyPolicy, KeyType, UsageFlags};
+
+    fn get_attrs() -> KeyAttributes {
+        KeyAttributes {
+            key_type: KeyType::EccKeyPair {
+                curve_family: EccFamily::SecpR1,
+            },
+            key_bits: 256,
+            key_policy: KeyPolicy {
+                key_usage_flags: UsageFlags {
+                    export: false,
+                    copy: false,
+                    cache: false,
+                    encrypt: false,
+                    decrypt: false,
+                    sign_message: false,
+                    verify_message: false,
+                    sign_hash: true,
+                    verify_hash: false,
+                    derive: false,
+                },
+                key_algorithm: Algorithm::AsymmetricSignature(AsymmetricSignature::Ecdsa {
+                    hash_alg: Hash::Sha256,
+                }),
+            },
+        }
+    }
+
+    #[test]
+    fn validate_success() {
+        (Operation {
+            key_name: String::from("some key"),
+            alg: AsymmetricSignature::Ecdsa {
+                hash_alg: Hash::Sha256,
+            },
+            hash: vec![0xff; 32],
+        })
+        .validate(get_attrs())
+        .unwrap();
+    }
+
+    #[test]
+    fn cannot_sign() {
+        let mut attrs = get_attrs();
+        attrs.key_policy.key_usage_flags.sign_hash = false;
+        assert_eq!(
+            (Operation {
+                key_name: String::from("some key"),
+                alg: AsymmetricSignature::Ecdsa {
+                    hash_alg: Hash::Sha256,
+                },
+                hash: vec![0xff; 32],
+            })
+            .validate(attrs)
+            .unwrap_err(),
+            ResponseStatus::PsaErrorNotPermitted
+        );
+    }
+
+    #[test]
+    fn wrong_algorithm() {
+        assert_eq!(
+            (Operation {
+                key_name: String::from("some key"),
+                alg: AsymmetricSignature::Ecdsa {
+                    hash_alg: Hash::Sha224,
+                },
+                hash: vec![0xff; 28],
+            })
+            .validate(get_attrs())
+            .unwrap_err(),
+            ResponseStatus::PsaErrorNotPermitted
+        );
+    }
+
+    #[test]
+    fn wrong_scheme() {
+        assert_eq!(
+            (Operation {
+                key_name: String::from("some key"),
+                alg: AsymmetricSignature::RsaPss {
+                    hash_alg: Hash::Sha224,
+                },
+                hash: vec![0xff; 28],
+            })
+            .validate(get_attrs())
+            .unwrap_err(),
+            ResponseStatus::PsaErrorNotPermitted
+        );
+    }
+
+    #[test]
+    fn invalid_hash() {
+        assert_eq!(
+            (Operation {
+                key_name: String::from("some key"),
+                alg: AsymmetricSignature::Ecdsa {
+                    hash_alg: Hash::Sha256,
+                },
+                hash: vec![0xff; 16],
+            })
+            .validate(get_attrs())
+            .unwrap_err(),
+            ResponseStatus::PsaErrorInvalidArgument
+        );
+    }
 }

--- a/src/operations/psa_verify_hash.rs
+++ b/src/operations/psa_verify_hash.rs
@@ -3,7 +3,9 @@
 //! # PsaVerifyHash operation
 //!
 //! Verify the signature of a hash or short message using a public key.
+use super::psa_key_attributes::KeyAttributes;
 use crate::operations::psa_algorithm::AsymmetricSignature;
+use crate::requests::ResponseStatus;
 
 /// Native object for asymmetric verification of signatures.
 #[derive(Debug)]
@@ -25,3 +27,140 @@ pub struct Operation {
 /// The true result of the operation is sent as a `status` code in the response.
 #[derive(Copy, Clone, Debug)]
 pub struct Result;
+
+impl Operation {
+    /// Validate the contents of the operation against the attributes of the key it targets
+    ///
+    /// This method checks that:
+    /// * the key policy allows verifying signatures on hashes
+    /// * the key policy allows the verification algorithm requested in the operation
+    /// * the key type is compatible with the requested algorithm
+    /// * the length of the given digest is consistent with the specified verification algorithm
+    pub fn validate(&self, key_attributes: KeyAttributes) -> crate::requests::Result<()> {
+        key_attributes.can_verify_hash()?;
+        key_attributes.permits_alg(self.alg.into())?;
+        key_attributes.compatible_with_alg(self.alg.into())?;
+        if !self.alg.is_hash_len_permitted(self.hash.len()) {
+            return Err(ResponseStatus::PsaErrorInvalidArgument);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::operations::psa_algorithm::{Algorithm, AsymmetricSignature, Hash};
+    use crate::operations::psa_key_attributes::{EccFamily, KeyPolicy, KeyType, UsageFlags};
+
+    fn get_attrs() -> KeyAttributes {
+        KeyAttributes {
+            key_type: KeyType::EccKeyPair {
+                curve_family: EccFamily::SecpR1,
+            },
+            key_bits: 256,
+            key_policy: KeyPolicy {
+                key_usage_flags: UsageFlags {
+                    export: false,
+                    copy: false,
+                    cache: false,
+                    encrypt: false,
+                    decrypt: false,
+                    sign_message: false,
+                    verify_message: false,
+                    sign_hash: false,
+                    verify_hash: true,
+                    derive: false,
+                },
+                key_algorithm: Algorithm::AsymmetricSignature(AsymmetricSignature::Ecdsa {
+                    hash_alg: Hash::Sha256,
+                }),
+            },
+        }
+    }
+
+    #[test]
+    fn validate_success() {
+        (Operation {
+            key_name: String::from("some key"),
+            alg: AsymmetricSignature::Ecdsa {
+                hash_alg: Hash::Sha256,
+            },
+            hash: vec![0xff; 32],
+            signature: vec![0xa5; 65],
+        })
+        .validate(get_attrs())
+        .unwrap();
+    }
+
+    #[test]
+    fn cannot_sign() {
+        let mut attrs = get_attrs();
+        attrs.key_policy.key_usage_flags.verify_hash = false;
+        assert_eq!(
+            (Operation {
+                key_name: String::from("some key"),
+                alg: AsymmetricSignature::Ecdsa {
+                    hash_alg: Hash::Sha256,
+                },
+                hash: vec![0xff; 32],
+                signature: vec![0xa5; 65],
+            })
+            .validate(attrs)
+            .unwrap_err(),
+            ResponseStatus::PsaErrorNotPermitted
+        );
+    }
+
+    #[test]
+    fn wrong_algorithm() {
+        assert_eq!(
+            (Operation {
+                key_name: String::from("some key"),
+                alg: AsymmetricSignature::Ecdsa {
+                    hash_alg: Hash::Sha224,
+                },
+                hash: vec![0xff; 28],
+                signature: vec![0xa5; 65],
+            })
+            .validate(get_attrs())
+            .unwrap_err(),
+            ResponseStatus::PsaErrorNotPermitted
+        );
+    }
+
+    #[test]
+    fn wrong_scheme() {
+        assert_eq!(
+            (Operation {
+                key_name: String::from("some key"),
+                alg: AsymmetricSignature::RsaPss {
+                    hash_alg: Hash::Sha224,
+                },
+                hash: vec![0xff; 28],
+                signature: vec![0xa5; 65],
+            })
+            .validate(get_attrs())
+            .unwrap_err(),
+            ResponseStatus::PsaErrorNotPermitted
+        );
+    }
+
+    #[test]
+    fn invalid_hash() {
+        assert_eq!(
+            (Operation {
+                key_name: String::from("some key"),
+                alg: AsymmetricSignature::Ecdsa {
+                    hash_alg: Hash::Sha256,
+                },
+                hash: vec![0xff; 16],
+                signature: vec![0xa5; 65],
+            })
+            .validate(get_attrs())
+            .unwrap_err(),
+            ResponseStatus::PsaErrorInvalidArgument
+        );
+    }
+}


### PR DESCRIPTION
This commit adds a `validate` method on sign hash and verify hash
operations. The purpose of this is to wrap consistency and policy checks
within one method, easing inspection of the policy enforcing code.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>