### PR TITLE
Implement DataBuffer and replace byte vectors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ arbitrary = { version = "0.4.4", features = ["derive"] }
 uuid = "0.7.4"
 log = "0.4.8"
 psa-crypto = { version = "0.2.0", default-features = false }
+zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
+secrecy = { version = "0.6.0", features = ["serde"] }
+derivative = "2.1.1"
 
 [features]
 testing = []

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ This project uses the following third party crates:
 * uuid (Apache-2.0)
 * log (MIT and Apache-2.0)
 * arbitrary (MIT and Apache-2.0)
+* zeroize (MIT and Apache-2.0)
+* secrecy (MIT and Apache-2.0)
+* derivative (MIT and Apache-2.0)
 
 ## Contributing
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,7 +174,7 @@
 //!        opcode: Opcode::Ping,
 //!    },
 //!    body: converter.operation_to_body(operation).unwrap(),
-//!    auth: RequestAuth::from_bytes(Vec::from("root")),
+//!    auth: RequestAuth::new(Vec::from("root")),
 //!};
 //!// stream is a Write object
 //!request.write_to_stream(&mut stream).unwrap();
@@ -226,3 +226,6 @@
 pub mod operations;
 pub mod operations_protobuf;
 pub mod requests;
+
+/// Module providing access to secret-wrapping functionality.
+pub use secrecy;

--- a/src/operations/psa_export_public_key.rs
+++ b/src/operations/psa_export_public_key.rs
@@ -17,5 +17,5 @@ pub struct Operation {
 pub struct Result {
     /// `data` holds the bytes defining the public key, formatted as specified
     /// by the provider for which the request was made.
-    pub data: Vec<u8>,
+    pub data: zeroize::Zeroizing<Vec<u8>>,
 }

--- a/src/operations/psa_import_key.rs
+++ b/src/operations/psa_import_key.rs
@@ -5,9 +5,11 @@
 //! Import a key in binary format.
 
 use super::psa_key_attributes::Attributes;
+use derivative::Derivative;
 
 /// Native object for cryptographic key importing operation.
-#[derive(Clone, Debug)]
+#[derive(Derivative)]
+#[derivative(Debug)]
 pub struct Operation {
     /// `key_name` specifies a name by which the service will identify the key. Key
     /// name must be unique per application.
@@ -17,7 +19,10 @@ pub struct Operation {
     /// `data` contains the bytes for the key,
     /// formatted in accordance with the requirements of the provider for the key type
     /// specified in `attributes`.
-    pub data: Vec<u8>,
+    // Debug is not derived for this because it could expose secrets if printed or logged
+    // somewhere
+    #[derivative(Debug = "ignore")]
+    pub data: crate::secrecy::Secret<Vec<u8>>,
 }
 
 /// Native object for the result of a cryptographic key import operation.

--- a/src/operations/psa_sign_hash.rs
+++ b/src/operations/psa_sign_hash.rs
@@ -17,7 +17,7 @@ pub struct Operation {
     /// compatible with the type of key.
     pub alg: AsymmetricSignature,
     /// The input whose signature is to be verified. This is usually the hash of a message.
-    pub hash: Vec<u8>,
+    pub hash: zeroize::Zeroizing<Vec<u8>>,
 }
 
 /// Native object for asymmetric sign result.
@@ -25,7 +25,7 @@ pub struct Operation {
 pub struct Result {
     /// The `signature` field contains the resulting bytes from the signing operation. The format of
     /// the signature is as specified by the provider doing the signing.
-    pub signature: Vec<u8>,
+    pub signature: zeroize::Zeroizing<Vec<u8>>,
 }
 
 impl Operation {
@@ -88,7 +88,7 @@ mod tests {
             alg: AsymmetricSignature::Ecdsa {
                 hash_alg: Hash::Sha256.into(),
             },
-            hash: vec![0xff; 32],
+            hash: vec![0xff; 32].into(),
         })
         .validate(get_attrs())
         .unwrap();
@@ -104,7 +104,7 @@ mod tests {
                 alg: AsymmetricSignature::Ecdsa {
                     hash_alg: Hash::Sha256.into(),
                 },
-                hash: vec![0xff; 32],
+                hash: vec![0xff; 32].into(),
             })
             .validate(attrs)
             .unwrap_err(),
@@ -120,7 +120,7 @@ mod tests {
                 alg: AsymmetricSignature::Ecdsa {
                     hash_alg: Hash::Sha224.into(),
                 },
-                hash: vec![0xff; 28],
+                hash: vec![0xff; 28].into(),
             })
             .validate(get_attrs())
             .unwrap_err(),
@@ -136,7 +136,7 @@ mod tests {
                 alg: AsymmetricSignature::RsaPss {
                     hash_alg: Hash::Sha224.into(),
                 },
-                hash: vec![0xff; 28],
+                hash: vec![0xff; 28].into(),
             })
             .validate(get_attrs())
             .unwrap_err(),
@@ -152,7 +152,7 @@ mod tests {
                 alg: AsymmetricSignature::Ecdsa {
                     hash_alg: Hash::Sha256.into(),
                 },
-                hash: vec![0xff; 16],
+                hash: vec![0xff; 16].into(),
             })
             .validate(get_attrs())
             .unwrap_err(),

--- a/src/operations/psa_verify_hash.rs
+++ b/src/operations/psa_verify_hash.rs
@@ -17,9 +17,9 @@ pub struct Operation {
     pub alg: AsymmetricSignature,
     /// The `hash` contains a short message or hash value as described for the
     /// asymmetric signing operation.
-    pub hash: Vec<u8>,
+    pub hash: zeroize::Zeroizing<Vec<u8>>,
     /// Buffer containing the signature to verify.
-    pub signature: Vec<u8>,
+    pub signature: zeroize::Zeroizing<Vec<u8>>,
 }
 
 /// Native object for asymmetric verification of signatures.
@@ -88,8 +88,8 @@ mod tests {
             alg: AsymmetricSignature::Ecdsa {
                 hash_alg: Hash::Sha256.into(),
             },
-            hash: vec![0xff; 32],
-            signature: vec![0xa5; 65],
+            hash: vec![0xff; 32].into(),
+            signature: vec![0xa5; 65].into(),
         })
         .validate(get_attrs())
         .unwrap();
@@ -105,8 +105,8 @@ mod tests {
                 alg: AsymmetricSignature::Ecdsa {
                     hash_alg: Hash::Sha256.into(),
                 },
-                hash: vec![0xff; 32],
-                signature: vec![0xa5; 65],
+                hash: vec![0xff; 32].into(),
+                signature: vec![0xa5; 65].into(),
             })
             .validate(attrs)
             .unwrap_err(),
@@ -122,8 +122,8 @@ mod tests {
                 alg: AsymmetricSignature::Ecdsa {
                     hash_alg: Hash::Sha224.into(),
                 },
-                hash: vec![0xff; 28],
-                signature: vec![0xa5; 65],
+                hash: vec![0xff; 28].into(),
+                signature: vec![0xa5; 65].into(),
             })
             .validate(get_attrs())
             .unwrap_err(),
@@ -139,8 +139,8 @@ mod tests {
                 alg: AsymmetricSignature::RsaPss {
                     hash_alg: Hash::Sha224.into(),
                 },
-                hash: vec![0xff; 28],
-                signature: vec![0xa5; 65],
+                hash: vec![0xff; 28].into(),
+                signature: vec![0xa5; 65].into(),
             })
             .validate(get_attrs())
             .unwrap_err(),
@@ -156,8 +156,8 @@ mod tests {
                 alg: AsymmetricSignature::Ecdsa {
                     hash_alg: Hash::Sha256.into(),
                 },
-                hash: vec![0xff; 16],
-                signature: vec![0xa5; 65],
+                hash: vec![0xff; 16].into(),
+                signature: vec![0xa5; 65].into(),
             })
             .validate(get_attrs())
             .unwrap_err(),

--- a/src/operations_protobuf/convert_psa_export_public_key.rs
+++ b/src/operations_protobuf/convert_psa_export_public_key.rs
@@ -32,7 +32,7 @@ impl TryFrom<ResultProto> for Result {
 
     fn try_from(proto_op: ResultProto) -> std::result::Result<Self, Self::Error> {
         Ok(Result {
-            data: proto_op.data,
+            data: proto_op.data.into(),
         })
     }
 }
@@ -41,7 +41,9 @@ impl TryFrom<Result> for ResultProto {
     type Error = ResponseStatus;
 
     fn try_from(op: Result) -> std::result::Result<Self, Self::Error> {
-        Ok(ResultProto { data: op.data })
+        Ok(ResultProto {
+            data: op.data.to_vec(),
+        })
     }
 }
 
@@ -92,14 +94,14 @@ mod test {
 
         let result: Result = proto.try_into().expect("Failed to convert");
 
-        assert_eq!(result.data, key_data);
+        assert_eq!(result.data, key_data.into());
     }
 
     #[test]
     fn asym_resp_to_proto() {
         let key_data = vec![0x11, 0x22, 0x33];
         let result = Result {
-            data: key_data.clone(),
+            data: key_data.clone().into(),
         };
 
         let proto: ResultProto = result.try_into().expect("Failed to convert");
@@ -124,7 +126,7 @@ mod test {
     #[test]
     fn resp_export_pk_e2e() {
         let result = Result {
-            data: vec![0x11, 0x22, 0x33],
+            data: vec![0x11, 0x22, 0x33].into(),
         };
         let body = CONVERTER
             .result_to_body(NativeResult::PsaExportPublicKey(result))

--- a/src/operations_protobuf/mod.rs
+++ b/src/operations_protobuf/mod.rs
@@ -32,6 +32,7 @@ use generated_ops::psa_generate_key as psa_generate_key_proto;
 use generated_ops::psa_import_key as psa_import_key_proto;
 use generated_ops::psa_sign_hash as psa_sign_hash_proto;
 use generated_ops::psa_verify_hash as psa_verify_hash_proto;
+use generated_ops::ClearProtoMessage;
 use prost::Message;
 use std::convert::TryInto;
 
@@ -47,11 +48,13 @@ macro_rules! wire_to_native {
 
 macro_rules! native_to_wire {
     ($native_msg:expr, $proto_type:ty) => {{
-        let proto: $proto_type = $native_msg.try_into()?;
+        let mut proto: $proto_type = $native_msg.try_into()?;
         let mut bytes = Vec::new();
         if proto.encode(&mut bytes).is_err() {
+            proto.clear_message();
             return Err(ResponseStatus::SerializingBodyFailed);
         }
+        proto.clear_message();
         bytes
     }};
 }

--- a/src/requests/request/request_auth.rs
+++ b/src/requests/request/request_auth.rs
@@ -1,6 +1,7 @@
 // Copyright 2019 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use crate::requests::Result;
+use crate::secrecy::{ExposeSecret, Secret};
 #[cfg(feature = "fuzz")]
 use arbitrary::Arbitrary;
 use std::io::{Read, Write};
@@ -9,49 +10,32 @@ use std::io::{Read, Write};
 ///
 /// Hides the contents and keeps them immutable.
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
-#[derive(Debug, Clone, Default, PartialEq)]
+#[allow(missing_debug_implementations)]
 pub struct RequestAuth {
-    bytes: Vec<u8>,
+    /// Buffer holding the authentication token as a byte vector
+    pub buffer: Secret<Vec<u8>>,
 }
 
 impl RequestAuth {
-    /// Construct new, empty request authentication field.
-    /// Available for testing only.
-    #[cfg(feature = "testing")]
-    pub(super) fn new() -> RequestAuth {
-        RequestAuth { bytes: Vec::new() }
+    /// Create a new authentication field for a request.
+    pub fn new(bytes: Vec<u8>) -> Self {
+        RequestAuth {
+            buffer: Secret::new(bytes),
+        }
     }
 
     /// Read a request authentication field from the stream, given the length
     /// of the byte stream contained.
     pub(super) fn read_from_stream(mut stream: &mut impl Read, len: usize) -> Result<RequestAuth> {
-        let bytes = get_from_stream!(stream; len);
-        Ok(RequestAuth { bytes })
+        let buffer = get_from_stream!(stream; len);
+        Ok(RequestAuth {
+            buffer: Secret::new(buffer),
+        })
     }
 
     /// Write request authentication field to stream.
     pub(super) fn write_to_stream(&self, stream: &mut impl Write) -> Result<()> {
-        stream.write_all(&self.bytes)?;
+        stream.write_all(&self.buffer.expose_secret())?;
         Ok(())
-    }
-
-    /// Create a `RequestAuth` from a vector of bytes.
-    pub fn from_bytes(bytes: Vec<u8>) -> RequestAuth {
-        RequestAuth { bytes }
-    }
-
-    /// Get the auth as a slice of bytes.
-    pub fn bytes(&self) -> &[u8] {
-        &self.bytes
-    }
-
-    /// Get the size of the auth field.
-    pub fn len(&self) -> usize {
-        self.bytes.len()
-    }
-
-    /// Check if auth field is empty.
-    pub fn is_empty(&self) -> bool {
-        self.bytes.is_empty()
     }
 }


### PR DESCRIPTION
This commit adds a new structure, DataBuffer, meant to clean up data
after it is released by zeroizing its content in `drop`.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>