### PR TITLE
Added the from impls for going from an operations and result to NativeOperation and NativeResult for asym encrypt and decrypt

### DIFF
--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -205,6 +205,18 @@ impl From<psa_verify_hash::Operation> for NativeOperation {
     }
 }
 
+impl From<psa_asymmetric_encrypt::Operation> for NativeOperation {
+    fn from(op: psa_asymmetric_encrypt::Operation) -> Self {
+        NativeOperation::PsaAsymmetricEncrypt(op)
+    }
+}
+
+impl From<psa_asymmetric_decrypt::Operation> for NativeOperation {
+    fn from(op: psa_asymmetric_decrypt::Operation) -> Self {
+        NativeOperation::PsaAsymmetricDecrypt(op)
+    }
+}
+
 impl From<list_providers::Result> for NativeResult {
     fn from(op: list_providers::Result) -> Self {
         NativeResult::ListProviders(op)
@@ -256,5 +268,17 @@ impl From<psa_sign_hash::Result> for NativeResult {
 impl From<psa_verify_hash::Result> for NativeResult {
     fn from(op: psa_verify_hash::Result) -> Self {
         NativeResult::PsaVerifyHash(op)
+    }
+}
+
+impl From<psa_asymmetric_encrypt::Result> for NativeResult {
+    fn from(op: psa_asymmetric_encrypt::Result) -> Self {
+        NativeResult::PsaAsymmetricEncrypt(op)
+    }
+}
+
+impl From<psa_asymmetric_decrypt::Result> for NativeResult {
+    fn from(op: psa_asymmetric_decrypt::Result) -> Self {
+        NativeResult::PsaAsymmetricDecrypt(op)
     }
 }


### PR DESCRIPTION
I noticed these were missing when writing the how-to for the Parsec book. They aren't used but I've added them for completeness.

Signed-off-by: Samuel Bailey <samuel.bailey@arm.com>