### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/operations_protobuf/convert_psa_algorithm.rs
+++ b/src/operations_protobuf/convert_psa_algorithm.rs
@@ -176,9 +176,9 @@ impl TryFrom<MacProto> for Mac {
                     error!("mac_alg field of mac::Truncated message is empty.");
                     ResponseStatus::InvalidEncoding
                 })?.try_into()?,
-                mac_length: truncated.mac_length.try_into().or_else(|e| {
+                mac_length: truncated.mac_length.try_into().map_err(|e| {
                     error!("mac_length field of mac::Truncated message can not be represented by an usize ({}).", e);
-                    Err(ResponseStatus::InvalidEncoding)
+                    ResponseStatus::InvalidEncoding
                 })?,
             }),
         }
@@ -200,12 +200,12 @@ impl TryFrom<Mac> for MacProto {
             } => Ok(MacProto {
                 variant: Some(mac::Variant::Truncated(mac::Truncated {
                     mac_alg: Some(mac_alg.try_into()?),
-                    mac_length: mac_length.try_into().or_else(|e| {
+                    mac_length: mac_length.try_into().map_err(|e| {
                         error!(
                             "mac_length field of Mac can not be represented by an u32 ({}).",
                             e
                         );
-                        Err(ResponseStatus::InvalidEncoding)
+                        ResponseStatus::InvalidEncoding
                     })?,
                 })),
             }),
@@ -293,9 +293,9 @@ impl TryFrom<AeadProto> for Aead {
             },
             aead::Variant::AeadWithShortenedTag(aead_with_shortened_tag) => Ok(Aead::AeadWithShortenedTag {
                 aead_alg: AeadWithDefaultLengthTagProto::try_from(aead_with_shortened_tag.aead_alg)?.try_into()?,
-                tag_length: aead_with_shortened_tag.tag_length.try_into().or_else(|e| {
+                tag_length: aead_with_shortened_tag.tag_length.try_into().map_err(|e| {
                         error!("tag_length field of aead::AeadWithShortenedTag can not be represented by an usize ({}).", e);
-                        Err(ResponseStatus::InvalidEncoding)
+                        ResponseStatus::InvalidEncoding
                 })?,
             }),
         }
@@ -314,9 +314,9 @@ impl TryFrom<Aead> for AeadProto {
             Aead::AeadWithShortenedTag { aead_alg, tag_length } => Ok(AeadProto {
                 variant: Some(aead::Variant::AeadWithShortenedTag(aead::AeadWithShortenedTag {
                     aead_alg: aead_with_default_length_tag_to_i32(aead_alg),
-                    tag_length: tag_length.try_into().or_else(|e| {
+                    tag_length: tag_length.try_into().map_err(|e| {
                         error!("tag_length field of Aead::AeadWithShortenedTag can not be represented by an u32 ({}).", e);
-                        Err(ResponseStatus::InvalidEncoding)
+                        ResponseStatus::InvalidEncoding
                     })?,
                 })),
             }),

--- a/src/operations_protobuf/convert_psa_key_attributes.rs
+++ b/src/operations_protobuf/convert_psa_key_attributes.rs
@@ -261,9 +261,9 @@ impl TryFrom<KeyAttributesProto> for Attributes {
                     ResponseStatus::InvalidEncoding
                 })?
                 .try_into()?,
-            bits: key_attributes_proto.key_bits.try_into().or_else(|e| {
+            bits: key_attributes_proto.key_bits.try_into().map_err(|e| {
                 error!("failed to convert key bits from proto. Error: {}", e);
-                Err(ResponseStatus::InvalidEncoding)
+                ResponseStatus::InvalidEncoding
             })?,
             policy: key_attributes_proto
                 .key_policy
@@ -283,9 +283,9 @@ impl TryFrom<Attributes> for KeyAttributesProto {
     fn try_from(key_attributes: Attributes) -> Result<Self> {
         Ok(KeyAttributesProto {
             key_type: Some(key_attributes.key_type.try_into()?),
-            key_bits: key_attributes.bits.try_into().or_else(|e| {
+            key_bits: key_attributes.bits.try_into().map_err(|e| {
                 error!("failed to convert key bits to proto. Error: {}", e);
-                Err(ResponseStatus::InvalidEncoding)
+                ResponseStatus::InvalidEncoding
             })?,
             key_policy: Some(key_attributes.policy.try_into()?),
         })


### PR DESCRIPTION
This commit fixes clippy warnings about `or_else` being used instead of
`map_err`.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>