### PR TITLE
Make `response_status` module public

### DIFF
--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -6,7 +6,7 @@
 //! service returns.
 use num_derive::FromPrimitive;
 
-mod response_status;
+pub mod response_status;
 
 pub mod utils;
 pub mod common;

--- a/src/requests/response_status.rs
+++ b/src/requests/response_status.rs
@@ -1,5 +1,9 @@
 // Copyright 2019 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
+//! # Response Status
+//!
+//! This module contains the definitions for Parsec's response statuses.
+
 use log::{error, warn};
 use num_derive::FromPrimitive;
 use std::convert::TryFrom;


### PR DESCRIPTION
This is a nice-to-have for `parsec-tool`; we want to be able to access
this module for error handling.

Signed-off-by: Joe Ellis <joe.ellis@arm.com>