### PR TITLE
Allow random provider IDs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@
 //!let result_body = converter.result_to_body(result).unwrap();
 //!let response = Response {
 //!    header: ResponseHeader {
-//!        provider: ProviderID::MbedCrypto,
+//!        provider: ProviderID::new(1),
 //!        session: 0,
 //!        content_type: BodyType::Protobuf,
 //!        opcode: Opcode::PsaGenerateKey,
@@ -166,7 +166,7 @@
 //!let operation = NativeOperation::Ping(Operation {});
 //!let request = Request {
 //!    header: RequestHeader {
-//!        provider: ProviderID::Core,
+//!        provider: ProviderID::core(),
 //!        session: 0,
 //!        content_type: BodyType::Protobuf,
 //!        accept_type: BodyType::Protobuf,

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -17,23 +17,28 @@ use arbitrary::Arbitrary;
 pub use request::Request;
 pub use response::Response;
 pub use response_status::{ResponseStatus, Result};
-use std::convert::TryFrom;
 
 /// Listing of provider types and their associated codes.
 ///
 /// Passed in headers as `provider`.
-#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
-#[derive(FromPrimitive, PartialEq, Eq, Hash, Copy, Clone, Debug)]
-#[repr(u8)]
-pub enum ProviderID {
-    /// Provider to use for core Parsec operations.
-    Core = 0,
-    /// Provider using Mbed Crypto software library.
-    MbedCrypto = 1,
-    /// Provider using a PKCS 11 compatible library.
-    Pkcs11 = 2,
-    /// Provider using a TSS 2.0 Enhanced System API library.
-    Tpm = 3,
+#[derive(PartialEq, Eq, Hash, Copy, Clone, Debug)]
+pub struct ProviderID(u8);
+
+impl ProviderID {
+    /// Create a new provider ID with the given value
+    pub fn new(id: u8) -> Self {
+        ProviderID(id)
+    }
+
+    /// Get the ID of the provider
+    pub fn id(&self) -> u8 {
+        self.0
+    }
+
+    /// Get the provider ID for the Core Provider
+    pub const fn core() -> Self {
+        ProviderID(0)
+    }
 }
 
 impl std::fmt::Display for ProviderID {
@@ -42,14 +47,9 @@ impl std::fmt::Display for ProviderID {
     }
 }
 
-impl TryFrom<u8> for ProviderID {
-    type Error = ResponseStatus;
-
-    fn try_from(provider_id: u8) -> ::std::result::Result<Self, Self::Error> {
-        match num::FromPrimitive::from_u8(provider_id) {
-            Some(provider_id) => Ok(provider_id),
-            None => Err(ResponseStatus::ProviderDoesNotExist),
-        }
+impl From<u8> for ProviderID {
+    fn from(provider_id: u8) -> Self {
+        ProviderID(provider_id)
     }
 }
 

--- a/src/requests/request/mod.rs
+++ b/src/requests/request/mod.rs
@@ -198,7 +198,7 @@ mod tests {
         let resp_hdr: ResponseHeader = req_hdr.into();
 
         let mut resp_hdr_exp = ResponseHeader::new();
-        resp_hdr_exp.provider = ProviderID::Core;
+        resp_hdr_exp.provider = ProviderID::core();
         resp_hdr_exp.session = 0x11_22_33_44_55_66_77_88;
         resp_hdr_exp.content_type = BodyType::Protobuf;
         resp_hdr_exp.opcode = Opcode::Ping;
@@ -230,7 +230,7 @@ mod tests {
         let body = RequestBody::from_bytes(vec![0x70, 0x80, 0x90]);
         let auth = RequestAuth::new(vec![0xa0, 0xb0, 0xc0]);
         let header = RequestHeader {
-            provider: ProviderID::Core,
+            provider: ProviderID::core(),
             session: 0x11_22_33_44_55_66_77_88,
             content_type: BodyType::Protobuf,
             accept_type: BodyType::Protobuf,

--- a/src/requests/request/request_header.rs
+++ b/src/requests/request/request_header.rs
@@ -35,7 +35,7 @@ impl RequestHeader {
     #[cfg(feature = "testing")]
     pub(crate) fn new() -> RequestHeader {
         RequestHeader {
-            provider: ProviderID::Core,
+            provider: ProviderID::core(),
             session: 0,
             content_type: BodyType::Protobuf,
             accept_type: BodyType::Protobuf,
@@ -91,7 +91,7 @@ impl From<RequestHeader> for Raw {
     fn from(header: RequestHeader) -> Self {
         Raw {
             flags: 0,
-            provider: header.provider as u8,
+            provider: header.provider.id(),
             session: header.session,
             content_type: header.content_type as u8,
             accept_type: header.accept_type as u8,

--- a/src/requests/response/mod.rs
+++ b/src/requests/response/mod.rs
@@ -188,7 +188,7 @@ mod tests {
     fn get_response() -> Response {
         let body = ResponseBody::from_bytes(vec![0x70, 0x80, 0x90]);
         let header = ResponseHeader {
-            provider: ProviderID::Core,
+            provider: ProviderID::core(),
             session: 0x11_22_33_44_55_66_77_88,
             content_type: BodyType::Protobuf,
             opcode: Opcode::Ping,

--- a/src/requests/response/response_header.rs
+++ b/src/requests/response/response_header.rs
@@ -27,7 +27,7 @@ impl ResponseHeader {
     /// Create a new response header with default field values.
     pub(crate) fn new() -> ResponseHeader {
         ResponseHeader {
-            provider: ProviderID::Core,
+            provider: ProviderID::core(),
             session: 0,
             content_type: BodyType::Protobuf,
             opcode: Opcode::Ping,
@@ -43,10 +43,7 @@ impl TryFrom<Raw> for ResponseHeader {
     type Error = ResponseStatus;
 
     fn try_from(header: Raw) -> Result<ResponseHeader> {
-        let provider: ProviderID = match FromPrimitive::from_u8(header.provider) {
-            Some(provider_id) => provider_id,
-            None => return Err(ResponseStatus::ProviderDoesNotExist),
-        };
+        let provider: ProviderID = header.provider.into();
 
         let content_type: BodyType = match FromPrimitive::from_u8(header.content_type) {
             Some(content_type) => content_type,
@@ -81,7 +78,7 @@ impl From<ResponseHeader> for Raw {
     fn from(header: ResponseHeader) -> Self {
         Raw {
             flags: 0,
-            provider: header.provider as u8,
+            provider: header.provider.id(),
             session: header.session,
             content_type: header.content_type as u8,
             accept_type: 0,


### PR DESCRIPTION
This commit changes the way provider IDs are handled, from a static list
of IDs to just a wrapper around u8. This will allow the random
distribution of IDs, but will mean looser restrictions that will only be
verifiable in the service in the backend handler.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>