### PR TITLE
Update psa-crypto version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ prost = "0.6.1"
 arbitrary = { version = "0.4.6", features = ["derive"], optional = true }
 uuid = "0.8.1"
 log = "0.4.11"
-psa-crypto = { version = "0.6.0", default-features = false }
+psa-crypto = { git = "https://github.com/parallaxsecond/rust-psa-crypto", rev = "18dd4dda96d8b61d2e112b9e6ad83e90fe768d78", default-features = false }
 zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
 secrecy = { version = "0.7.0", features = ["serde"] }
 derivative = "2.1.1"

--- a/src/requests/response_status.rs
+++ b/src/requests/response_status.rs
@@ -173,10 +173,16 @@ impl fmt::Display for ResponseStatus {
                 write!(f, "request did not provide a required authentication")
             }
             ResponseStatus::BodySizeExceedsLimit => {
-                write!(f, "request length specified in the header is above defined limit")
+                write!(
+                    f,
+                    "request length specified in the header is above defined limit"
+                )
             }
             ResponseStatus::PsaErrorGenericError => {
-                write!(f, "an error occurred that does not correspond to any defined failure cause")
+                write!(
+                    f,
+                    "an error occurred that does not correspond to any defined failure cause"
+                )
             }
             ResponseStatus::PsaErrorNotPermitted => {
                 write!(f, "the requested action is denied by a policy")
@@ -191,7 +197,10 @@ impl fmt::Display for ResponseStatus {
                 write!(f, "the key handle is not valid")
             }
             ResponseStatus::PsaErrorBadState => {
-                write!(f, "the requested action cannot be performed in the current state")
+                write!(
+                    f,
+                    "the requested action cannot be performed in the current state"
+                )
             }
             ResponseStatus::PsaErrorBufferTooSmall => {
                 write!(f, "an output buffer is too small")
@@ -209,19 +218,31 @@ impl fmt::Display for ResponseStatus {
                 write!(f, "there is not enough persistent storage")
             }
             ResponseStatus::PsaErrorInsufficientData => {
-                write!(f, "insufficient data when attempting to read from a resource")
+                write!(
+                    f,
+                    "insufficient data when attempting to read from a resource"
+                )
             }
             ResponseStatus::PsaErrorCommunicationFailure => {
-                write!(f, "there was a communication failure inside the implementation")
+                write!(
+                    f,
+                    "there was a communication failure inside the implementation"
+                )
             }
             ResponseStatus::PsaErrorStorageFailure => {
-                write!(f, "there was a storage failure that may have led to data loss")
+                write!(
+                    f,
+                    "there was a storage failure that may have led to data loss"
+                )
             }
             ResponseStatus::PsaErrorDataCorrupt => {
                 write!(f, "stored data has been corrupted")
             }
             ResponseStatus::PsaErrorDataInvalid => {
-                write!(f, "data read from storage is not valid for the implementation")
+                write!(
+                    f,
+                    "data read from storage is not valid for the implementation"
+                )
             }
             ResponseStatus::PsaErrorHardwareFailure => {
                 write!(f, "a hardware failure was detected")
@@ -280,6 +301,26 @@ impl From<uuid::Error> for ResponseStatus {
 
 impl From<std::num::TryFromIntError> for ResponseStatus {
     fn from(err: std::num::TryFromIntError) -> Self {
+        warn!(
+            "Conversion from {} to ResponseStatus::InvalidEncoding.",
+            err
+        );
+        ResponseStatus::InvalidEncoding
+    }
+}
+
+impl From<std::array::TryFromSliceError> for ResponseStatus {
+    fn from(err: std::array::TryFromSliceError) -> Self {
+        warn!(
+            "Conversion from {} to ResponseStatus::InvalidEncoding.",
+            err
+        );
+        ResponseStatus::InvalidEncoding
+    }
+}
+
+impl From<std::ffi::NulError> for ResponseStatus {
+    fn from(err: std::ffi::NulError) -> Self {
         warn!(
             "Conversion from {} to ResponseStatus::InvalidEncoding.",
             err


### PR DESCRIPTION
Also adds some conversion to std error types for easier handling in
Parsec.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>