### PR TITLE
Add CryptoAuthLib to Provider enumeration.

### DIFF
--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -36,6 +36,8 @@ pub enum ProviderID {
     Tpm = 3,
     /// Provider using the crypto Trusted Service running in TrustZone
     TrustedService = 4,
+    /// Provider using the MicrochipTech cryptodevice ATECCx08 via CryptoAuthentication Library
+    CryptoAuthLib = 5,
 }
 
 impl std::fmt::Display for ProviderID {


### PR DESCRIPTION
An interface extension: a new Parsec provider using ATECCx08 cryptochip via CryptoAuthentication Library.