### PR TITLE
Consume psa-crypto at version 0.6.1 and bump interface to 0.22.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parsec-interface"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Paul Howard <paul.howard@arm.com>",
            "Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]
@@ -25,7 +25,7 @@ prost = "0.6.1"
 arbitrary = { version = "0.4.6", features = ["derive"], optional = true }
 uuid = "0.8.1"
 log = "0.4.11"
-psa-crypto = { git = "https://github.com/parallaxsecond/rust-psa-crypto", rev = "18dd4dda96d8b61d2e112b9e6ad83e90fe768d78", default-features = false }
+psa-crypto = { version = "0.6.1", default-features = false }
 zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
 secrecy = { version = "0.7.0", features = ["serde"] }
 derivative = "2.1.1"


### PR DESCRIPTION
Signed-off-by: Paul Howard <paul.howard@arm.com>