### PR TITLE
Bump PSA Crypto version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parsec-interface"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Paul Howard <paul.howard@arm.com>",
            "Ionut Mihalcea <ionut.mihalcea@arm.com>",
            "Hugues de Valon <hugues.devalon@arm.com>"]
@@ -25,7 +25,7 @@ prost = "0.6.1"
 arbitrary = { version = "0.4.6", features = ["derive"], optional = true }
 uuid = "0.8.1"
 log = "0.4.11"
-psa-crypto = { version = "0.6.1", default-features = false }
+psa-crypto = { version = "0.7.0", default-features = false }
 zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
 secrecy = { version = "0.7.0", features = ["serde"] }
 derivative = "2.1.1"

--- a/src/operations_protobuf/convert_delete_client.rs
+++ b/src/operations_protobuf/convert_delete_client.rs
@@ -36,9 +36,9 @@ mod test {
 
     #[test]
     fn proto_to_resp() {
-        let mut proto: OperationProto = Default::default();
-
-        proto.client = String::from("toto");
+        let proto = OperationProto {
+            client: String::from("toto"),
+        };
 
         let resp: Operation = proto.into();
 


### PR DESCRIPTION
This commit bumps the PSA Crypto version imported and fixes a lint bug
in a unit test.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>