### PR TITLE
Add PsaSignMessage and PsaVerifyMessage operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ prost = "0.6.1"
 arbitrary = { version = "0.4.6", features = ["derive"], optional = true }
 uuid = "0.8.1"
 log = "0.4.11"
-psa-crypto = { version = "0.8.0", default-features = false }
+psa-crypto = { git = "https://github.com/parallaxsecond/rust-psa-crypto", rev = "15ba7cd048923ae7193b268df51c004e8ceff48e", default-features = false }
 zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
 secrecy = { version = "0.7.0", features = ["serde"] }
 derivative = "2.1.1"

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -206,7 +206,7 @@ impl NativeResult {
             NativeResult::PsaGenerateRandom(_) => Opcode::PsaGenerateRandom,
             NativeResult::PsaRawKeyAgreement(_) => Opcode::PsaRawKeyAgreement,
             NativeResult::PsaSignMessage(_) => Opcode::PsaSignMessage,
-            NativeResult::PsaverifyMessage(_) => Opcode::PsaVerifyMessage,
+            NativeResult::PsaVerifyMessage(_) => Opcode::PsaVerifyMessage,
         }
     }
 }

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -23,6 +23,8 @@ pub mod psa_asymmetric_encrypt;
 pub mod psa_asymmetric_decrypt;
 pub mod psa_aead_encrypt;
 pub mod psa_aead_decrypt;
+pub mod psa_sign_message;
+pub mod psa_verify_message;
 pub mod list_opcodes;
 pub mod list_providers;
 pub mod list_authenticators;
@@ -85,6 +87,10 @@ pub enum NativeOperation {
     PsaGenerateRandom(psa_generate_random::Operation),
     /// PsaRawKeyAgreement operation
     PsaRawKeyAgreement(psa_raw_key_agreement::Operation),
+    /// PsaSignMessage operation
+    PsaSignMessage(psa_sign_message::Operation),
+    /// PsaVerifyMessage operation
+    PsaVerifyMessage(psa_verify_message::Operation),
 }
 
 impl NativeOperation {
@@ -113,6 +119,8 @@ impl NativeOperation {
             NativeOperation::PsaAeadDecrypt(_) => Opcode::PsaAeadDecrypt,
             NativeOperation::PsaGenerateRandom(_) => Opcode::PsaGenerateRandom,
             NativeOperation::PsaRawKeyAgreement(_) => Opcode::PsaRawKeyAgreement,
+            NativeOperation::PsaSignMessage(_) => Opcode::PsaSignMessage,
+            NativeOperation::PsaVerifyMessage(_) => Opcode::PsaVerifyMessage,
         }
     }
 }
@@ -165,6 +173,10 @@ pub enum NativeResult {
     PsaGenerateRandom(psa_generate_random::Result),
     /// PsaRawKeyAgreement result
     PsaRawKeyAgreement(psa_raw_key_agreement::Result),
+    /// PsaSignMessage result
+    PsaSignMessage(psa_sign_message::Result),
+    /// PsaVerifyMessage result
+    PsaVerifyMessage(psa_verify_message::Result),
 }
 
 impl NativeResult {
@@ -193,6 +205,8 @@ impl NativeResult {
             NativeResult::PsaAeadDecrypt(_) => Opcode::PsaAeadDecrypt,
             NativeResult::PsaGenerateRandom(_) => Opcode::PsaGenerateRandom,
             NativeResult::PsaRawKeyAgreement(_) => Opcode::PsaRawKeyAgreement,
+            NativeResult::PsaSignMessage(_) => Opcode::PsaSignMessage,
+            NativeResult::PsaverifyMessage(_) => Opcode::PsaVerifyMessage,
         }
     }
 }
@@ -358,6 +372,16 @@ impl From<psa_raw_key_agreement::Operation> for NativeOperation {
         NativeOperation::PsaRawKeyAgreement(op)
     }
 }
+impl From<psa_sign_message::Operation> for NativeOperation {
+    fn from(op: psa_sign_message::Operation) -> Self {
+        NativeOperation::PsaSignMessage(op)
+    }
+}
+impl From<psa_verify_message::Operation> for NativeOperation {
+    fn from(op: psa_verify_message::Operation) -> Self {
+        NativeOperation::PsaVerifyMessage(op)
+    }
+}
 
 impl From<list_providers::Result> for NativeResult {
     fn from(op: list_providers::Result) -> Self {
@@ -488,5 +512,17 @@ impl From<psa_generate_random::Result> for NativeResult {
 impl From<psa_raw_key_agreement::Result> for NativeResult {
     fn from(op: psa_raw_key_agreement::Result) -> Self {
         NativeResult::PsaRawKeyAgreement(op)
+    }
+}
+
+impl From<psa_sign_message::Result> for NativeResult {
+    fn from(op: psa_sign_message::Result) -> Self {
+        NativeResult::PsaSignMessage(op)
+    }
+}
+
+impl From<psa_verify_message::Result> for NativeResult {
+    fn from(op: psa_verify_message::Result) -> Self {
+        NativeResult::PsaVerifyMessage(op)
     }
 }

--- a/src/operations/psa_sign_message.rs
+++ b/src/operations/psa_sign_message.rs
@@ -1,0 +1,45 @@
+// Copyright 2019 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+//! # PsaSignMessage operation
+//! 
+//! //! Sign an hash generated from message with a private key.
+
+use super::psa_key_attributes::Attributes;
+use crate::operations::psa_algorithm::AsymmetricSignature;
+use crate::requests::ResponseStatus;
+
+/// Native object for asymmetric sign operations.
+#[derive(Debug)]
+pub struct Operation {
+    /// Defines which key should be used for the signing operation.
+    pub key_name: String,
+    /// An asymmetric signature algorithm that separates the hash and sign operations, that is
+    /// compatible with the type of key.
+    pub alg: AsymmetricSignature,
+    /// The input whose signature is to be verified. This is usually the hash of a message.
+    pub message: zeroize::Zeroizing<Vec<u8>>,
+}
+
+/// Native object for asymmetric sign result.
+#[derive(Debug)]
+pub struct Result {
+    /// The `signature` field contains the resulting bytes from the signing operation. The format of
+    /// the signature is as specified by the provider doing the signing.
+    pub signature: zeroize::Zeroizing<Vec<u8>>,
+}
+
+impl Operation {
+    /// Validate the contents of the operation against the attributes of the key it targets
+    ///
+    /// This method checks that:
+    /// * the key policy allows signing messages
+    /// * the key policy allows the signing algorithm requested in the operation
+    /// * the key type is compatible with the requested algorithm
+    pub fn validate(&self, key_attributes: Attributes) -> crate::requests::Result<()> {
+        key_attributes.can_sign_message()?;
+        key_attributes.permits_alg(self.alg.into())?;
+        key_attributes.compatible_with_alg(self.alg.into())?;
+
+        Ok(())
+    }
+}

--- a/src/operations/psa_sign_message.rs
+++ b/src/operations/psa_sign_message.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! # PsaSignMessage operation
 //!
-//! //! Sign an hash generated from message with a private key.
+//! Sign a message with a private key.
 
 use super::psa_key_attributes::Attributes;
 use crate::operations::psa_algorithm::AsymmetricSignature;

--- a/src/operations/psa_sign_message.rs
+++ b/src/operations/psa_sign_message.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Contributors to the Parsec project.
+// Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 //! # PsaSignMessage operation
 //!
@@ -15,7 +15,7 @@ pub struct Operation {
     /// An asymmetric signature algorithm that separates the hash and sign operations, that is
     /// compatible with the type of key.
     pub alg: AsymmetricSignature,
-    /// The input whose signature is to be verified. This is usually the hash of a message.
+    /// The message to sign.
     pub message: zeroize::Zeroizing<Vec<u8>>,
 }
 

--- a/src/operations/psa_sign_message.rs
+++ b/src/operations/psa_sign_message.rs
@@ -93,6 +93,7 @@ mod tests {
     #[test]
     fn cannot_sign() {
         let mut attrs = get_attrs();
+        attrs.policy.usage_flags.sign_hash = false;
         attrs.policy.usage_flags.sign_message = false;
         assert_eq!(
             (Operation {

--- a/src/operations/psa_sign_message.rs
+++ b/src/operations/psa_sign_message.rs
@@ -139,5 +139,4 @@ mod tests {
             ResponseStatus::PsaErrorNotPermitted
         );
     }
-
 }

--- a/src/operations/psa_sign_message.rs
+++ b/src/operations/psa_sign_message.rs
@@ -1,12 +1,11 @@
 // Copyright 2019 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 //! # PsaSignMessage operation
-//! 
+//!
 //! //! Sign an hash generated from message with a private key.
 
 use super::psa_key_attributes::Attributes;
 use crate::operations::psa_algorithm::AsymmetricSignature;
-use crate::requests::ResponseStatus;
 
 /// Native object for asymmetric sign operations.
 #[derive(Debug)]
@@ -36,7 +35,7 @@ impl Operation {
     /// * the key policy allows the signing algorithm requested in the operation
     /// * the key type is compatible with the requested algorithm
     pub fn validate(&self, key_attributes: Attributes) -> crate::requests::Result<()> {
-        key_attributes.can_sign_message()?;
+        key_attributes.can_sign_hash()?;
         key_attributes.permits_alg(self.alg.into())?;
         key_attributes.compatible_with_alg(self.alg.into())?;
 

--- a/src/operations/psa_verify_message.rs
+++ b/src/operations/psa_verify_message.rs
@@ -5,7 +5,6 @@
 //! Verify the signature of a hash or short message using a public key.
 use super::psa_key_attributes::Attributes;
 use crate::operations::psa_algorithm::AsymmetricSignature;
-use crate::requests::ResponseStatus;
 
 /// Native object for asymmetric verification of signatures.
 #[derive(Debug)]
@@ -36,7 +35,7 @@ impl Operation {
     /// * the key policy allows the verification algorithm requested in the operation
     /// * the key type is compatible with the requested algorithm
     pub fn validate(&self, key_attributes: Attributes) -> crate::requests::Result<()> {
-        key_attributes.can_verify_message()?;
+        key_attributes.can_verify_hash()?;
         key_attributes.permits_alg(self.alg.into())?;
         key_attributes.compatible_with_alg(self.alg.into())?;
 

--- a/src/operations/psa_verify_message.rs
+++ b/src/operations/psa_verify_message.rs
@@ -1,8 +1,8 @@
-// Copyright 2019 Contributors to the Parsec project.
+// Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 //! # PsaVerifyMessage operation
 //!
-//! Verify the signature of a hash or short message using a public key.
+//! Verify the signature of a message using a public key.
 use super::psa_key_attributes::Attributes;
 use crate::operations::psa_algorithm::AsymmetricSignature;
 
@@ -14,7 +14,7 @@ pub struct Operation {
     /// An asymmetric signature algorithm that separates the hash and sign operations, that is
     /// compatible with the type of key.
     pub alg: AsymmetricSignature,
-    /// The `message` contains a short message for the
+    /// The `message` whose signature is to be verified for the
     /// asymmetric signing operation.
     pub message: zeroize::Zeroizing<Vec<u8>>,
     /// Buffer containing the signature to verify.

--- a/src/operations/psa_verify_message.rs
+++ b/src/operations/psa_verify_message.rs
@@ -14,7 +14,7 @@ pub struct Operation {
     /// An asymmetric signature algorithm that separates the hash and sign operations, that is
     /// compatible with the type of key.
     pub alg: AsymmetricSignature,
-    /// The `hash` contains a short message or hash value as described for the
+    /// The `message` contains a short message for the
     /// asymmetric signing operation.
     pub message: zeroize::Zeroizing<Vec<u8>>,
     /// Buffer containing the signature to verify.
@@ -65,7 +65,7 @@ mod tests {
                     encrypt: false,
                     decrypt: false,
                     sign_message: false,
-                    verify_message: false,
+                    verify_message: true,
                     sign_hash: false,
                     verify_hash: true,
                     derive: false,

--- a/src/operations/psa_verify_message.rs
+++ b/src/operations/psa_verify_message.rs
@@ -1,0 +1,45 @@
+// Copyright 2019 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+//! # PsaVerifyMessage operation
+//!
+//! Verify the signature of a hash or short message using a public key.
+use super::psa_key_attributes::Attributes;
+use crate::operations::psa_algorithm::AsymmetricSignature;
+use crate::requests::ResponseStatus;
+
+/// Native object for asymmetric verification of signatures.
+#[derive(Debug)]
+pub struct Operation {
+    /// `key_name` specifies the key to be used for verification.
+    pub key_name: String,
+    /// An asymmetric signature algorithm that separates the hash and sign operations, that is
+    /// compatible with the type of key.
+    pub alg: AsymmetricSignature,
+    /// The `hash` contains a short message or hash value as described for the
+    /// asymmetric signing operation.
+    pub message: zeroize::Zeroizing<Vec<u8>>,
+    /// Buffer containing the signature to verify.
+    pub signature: zeroize::Zeroizing<Vec<u8>>,
+}
+
+/// Native object for asymmetric verification of signatures.
+///
+/// The true result of the operation is sent as a `status` code in the response.
+#[derive(Copy, Clone, Debug)]
+pub struct Result;
+
+impl Operation {
+    /// Validate the contents of the operation against the attributes of the key it targets
+    ///
+    /// This method checks that:
+    /// * the key policy allows verifying signatures on messages
+    /// * the key policy allows the verification algorithm requested in the operation
+    /// * the key type is compatible with the requested algorithm
+    pub fn validate(&self, key_attributes: Attributes) -> crate::requests::Result<()> {
+        key_attributes.can_verify_message()?;
+        key_attributes.permits_alg(self.alg.into())?;
+        key_attributes.compatible_with_alg(self.alg.into())?;
+
+        Ok(())
+    }
+}

--- a/src/operations/psa_verify_message.rs
+++ b/src/operations/psa_verify_message.rs
@@ -35,10 +35,112 @@ impl Operation {
     /// * the key policy allows the verification algorithm requested in the operation
     /// * the key type is compatible with the requested algorithm
     pub fn validate(&self, key_attributes: Attributes) -> crate::requests::Result<()> {
-        key_attributes.can_verify_hash()?;
+        key_attributes.can_verify_message()?;
         key_attributes.permits_alg(self.alg.into())?;
         key_attributes.compatible_with_alg(self.alg.into())?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::operations::psa_algorithm::{Algorithm, AsymmetricSignature, Hash};
+    use crate::operations::psa_key_attributes::{EccFamily, Lifetime, Policy, Type, UsageFlags};
+    use crate::requests::ResponseStatus;
+
+    fn get_attrs() -> Attributes {
+        Attributes {
+            lifetime: Lifetime::Persistent,
+            key_type: Type::EccKeyPair {
+                curve_family: EccFamily::SecpR1,
+            },
+            bits: 256,
+            policy: Policy {
+                usage_flags: UsageFlags {
+                    export: false,
+                    copy: false,
+                    cache: false,
+                    encrypt: false,
+                    decrypt: false,
+                    sign_message: false,
+                    verify_message: false,
+                    sign_hash: false,
+                    verify_hash: true,
+                    derive: false,
+                },
+                permitted_algorithms: Algorithm::AsymmetricSignature(AsymmetricSignature::Ecdsa {
+                    hash_alg: Hash::Sha256.into(),
+                }),
+            },
+        }
+    }
+
+    #[test]
+    fn validate_success() {
+        (Operation {
+            key_name: String::from("some key"),
+            alg: AsymmetricSignature::Ecdsa {
+                hash_alg: Hash::Sha256.into(),
+            },
+            message: vec![0xff; 32].into(),
+            signature: vec![0xa5; 65].into(),
+        })
+        .validate(get_attrs())
+        .unwrap();
+    }
+
+    #[test]
+    fn cannot_sign() {
+        let mut attrs = get_attrs();
+        attrs.policy.usage_flags.verify_message = false;
+        assert_eq!(
+            (Operation {
+                key_name: String::from("some key"),
+                alg: AsymmetricSignature::Ecdsa {
+                    hash_alg: Hash::Sha256.into(),
+                },
+                message: vec![0xff; 32].into(),
+                signature: vec![0xa5; 65].into(),
+            })
+            .validate(attrs)
+            .unwrap_err(),
+            ResponseStatus::PsaErrorNotPermitted
+        );
+    }
+
+    #[test]
+    fn wrong_algorithm() {
+        assert_eq!(
+            (Operation {
+                key_name: String::from("some key"),
+                alg: AsymmetricSignature::Ecdsa {
+                    hash_alg: Hash::Sha224.into(),
+                },
+                message: vec![0xff; 28].into(),
+                signature: vec![0xa5; 65].into(),
+            })
+            .validate(get_attrs())
+            .unwrap_err(),
+            ResponseStatus::PsaErrorNotPermitted
+        );
+    }
+
+    #[test]
+    fn wrong_scheme() {
+        assert_eq!(
+            (Operation {
+                key_name: String::from("some key"),
+                alg: AsymmetricSignature::RsaPss {
+                    hash_alg: Hash::Sha224.into(),
+                },
+                message: vec![0xff; 28].into(),
+                signature: vec![0xa5; 65].into(),
+            })
+            .validate(get_attrs())
+            .unwrap_err(),
+            ResponseStatus::PsaErrorNotPermitted
+        );
     }
 }

--- a/src/operations/psa_verify_message.rs
+++ b/src/operations/psa_verify_message.rs
@@ -94,6 +94,7 @@ mod tests {
     #[test]
     fn cannot_sign() {
         let mut attrs = get_attrs();
+        attrs.policy.usage_flags.verify_hash = false;
         attrs.policy.usage_flags.verify_message = false;
         assert_eq!(
             (Operation {

--- a/src/operations_protobuf/convert_psa_sign_message.rs
+++ b/src/operations_protobuf/convert_psa_sign_message.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Contributors to the Parsec project.
+// Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use super::generated_ops::psa_sign_message::{Operation as OperationProto, Result as ResultProto};
 use crate::operations::psa_sign_message::{Operation, Result};
@@ -56,5 +56,137 @@ impl TryFrom<Result> for ResultProto {
         Ok(ResultProto {
             signature: result.signature.to_vec(),
         })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::generated_ops::psa_algorithm as algorithm_proto;
+    use super::super::generated_ops::psa_sign_message::{
+        Operation as OperationProto, Result as ResultProto,
+    };
+    use super::super::{Convert, ProtobufConverter};
+    use crate::operations::psa_algorithm::AsymmetricSignature;
+    use crate::operations::psa_sign_message::{Operation, Result};
+    use crate::operations::{NativeOperation, NativeResult};
+    use crate::requests::{request::RequestBody, response::ResponseBody, Opcode};
+    use std::convert::TryInto;
+
+    static CONVERTER: ProtobufConverter = ProtobufConverter {};
+
+    #[test]
+    fn asym_proto_to_op() {
+        let mut proto: OperationProto = Default::default();
+        let hash = vec![0x11, 0x22, 0x33];
+        let key_name = "test name".to_string();
+        proto.message = hash.clone();
+        proto.alg = Some(algorithm_proto::algorithm::AsymmetricSignature {
+            variant: Some(
+                algorithm_proto::algorithm::asymmetric_signature::Variant::RsaPkcs1v15Sign(
+                    algorithm_proto::algorithm::asymmetric_signature::RsaPkcs1v15Sign {
+                        hash_alg: Some(algorithm_proto::algorithm::asymmetric_signature::SignHash {
+                            variant: Some(algorithm_proto::algorithm::asymmetric_signature::sign_hash::Variant::Specific(
+                                algorithm_proto::algorithm::Hash::Sha1.into(),
+                            )),
+                        }),
+                    },
+                ),
+            ),
+        });
+        proto.key_name = key_name.clone();
+
+        let op: Operation = proto.try_into().expect("Failed to convert");
+
+        assert_eq!(op.message, hash.into());
+        assert_eq!(op.key_name, key_name);
+    }
+
+    #[test]
+    fn asym_op_to_proto() {
+        let hash = vec![0x11, 0x22, 0x33];
+        let key_name = "test name".to_string();
+
+        let op = Operation {
+            message: hash.clone().into(),
+            alg: AsymmetricSignature::RsaPkcs1v15SignRaw,
+            key_name: key_name.clone(),
+        };
+
+        let proto: OperationProto = op.try_into().expect("Failed to convert");
+
+        assert_eq!(proto.message, hash);
+        assert_eq!(proto.key_name, key_name);
+    }
+
+    #[test]
+    fn asym_proto_to_resp() {
+        let mut proto: ResultProto = Default::default();
+        let signature = vec![0x11, 0x22, 0x33];
+        proto.signature = signature.clone();
+
+        let result: Result = proto.try_into().expect("Failed to convert");
+
+        assert_eq!(result.signature, signature.into());
+    }
+
+    #[test]
+    fn asym_resp_to_proto() {
+        let signature = vec![0x11, 0x22, 0x33];
+        let result = Result {
+            signature: signature.clone().into(),
+        };
+
+        let proto: ResultProto = result.try_into().expect("Failed to convert");
+
+        assert_eq!(proto.signature, signature);
+    }
+
+    #[test]
+    fn op_asym_sign_e2e() {
+        let op = Operation {
+            message: vec![0x11, 0x22, 0x33].into(),
+            alg: AsymmetricSignature::RsaPkcs1v15SignRaw,
+            key_name: "test name".to_string(),
+        };
+        let body = CONVERTER
+            .operation_to_body(NativeOperation::PsaSignMessage(op))
+            .expect("Failed to convert request");
+
+        assert!(CONVERTER
+            .body_to_operation(body, Opcode::PsaSignMessage)
+            .is_ok());
+    }
+
+    #[test]
+    fn resp_asym_sign_e2e() {
+        let result = Result {
+            signature: vec![0x11, 0x22, 0x33].into(),
+        };
+        let body = CONVERTER
+            .result_to_body(NativeResult::PsaSignMessage(result))
+            .expect("Failed to convert request");
+
+        assert!(CONVERTER
+            .body_to_result(body, Opcode::PsaSignMessage)
+            .is_ok());
+    }
+
+    #[test]
+    fn result_from_mangled_resp_body() {
+        let resp_body =
+            ResponseBody::from_bytes(vec![0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88]);
+        assert!(CONVERTER
+            .body_to_result(resp_body, Opcode::PsaSignMessage)
+            .is_err());
+    }
+
+    #[test]
+    fn op_from_mangled_req_body() {
+        let req_body =
+            RequestBody::from_bytes(vec![0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88]);
+
+        assert!(CONVERTER
+            .body_to_operation(req_body, Opcode::PsaSignMessage)
+            .is_err());
     }
 }

--- a/src/operations_protobuf/convert_psa_sign_message.rs
+++ b/src/operations_protobuf/convert_psa_sign_message.rs
@@ -1,0 +1,60 @@
+// Copyright 2019 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use super::generated_ops::psa_sign_message::{Operation as OperationProto, Result as ResultProto};
+use crate::operations::psa_sign_message::{Operation, Result};
+use crate::requests::ResponseStatus;
+use log::error;
+use std::convert::{TryFrom, TryInto};
+use zeroize::Zeroizing;
+
+impl TryFrom<OperationProto> for Operation {
+    type Error = ResponseStatus;
+
+    fn try_from(proto_op: OperationProto) -> std::result::Result<Self, Self::Error> {
+        let message = Zeroizing::new(proto_op.message);
+        Ok(Operation {
+            key_name: proto_op.key_name,
+            alg: proto_op
+                .alg
+                .ok_or_else(|| {
+                    error!("alg field of psa_sign_message::Operation message is empty.");
+                    ResponseStatus::InvalidEncoding
+                })?
+                .try_into()?,
+            message,
+        })
+    }
+}
+
+impl TryFrom<Operation> for OperationProto {
+    type Error = ResponseStatus;
+
+    fn try_from(op: Operation) -> std::result::Result<Self, Self::Error> {
+        let alg = Some(op.alg.try_into()?);
+        Ok(OperationProto {
+            key_name: op.key_name,
+            alg,
+            message: op.message.to_vec(),
+        })
+    }
+}
+
+impl TryFrom<ResultProto> for Result {
+    type Error = ResponseStatus;
+
+    fn try_from(proto_result: ResultProto) -> std::result::Result<Self, Self::Error> {
+        Ok(Result {
+            signature: proto_result.signature.into(),
+        })
+    }
+}
+
+impl TryFrom<Result> for ResultProto {
+    type Error = ResponseStatus;
+
+    fn try_from(result: Result) -> std::result::Result<Self, Self::Error> {
+        Ok(ResultProto {
+            signature: result.signature.to_vec(),
+        })
+    }
+}

--- a/src/operations_protobuf/convert_psa_verify_message.rs
+++ b/src/operations_protobuf/convert_psa_verify_message.rs
@@ -1,0 +1,59 @@
+// Copyright 2019 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use super::generated_ops::psa_verify_message::{Operation as OperationProto, Result as ResultProto};
+use crate::operations::psa_verify_message::{Operation, Result};
+use crate::requests::ResponseStatus;
+use log::error;
+use std::convert::{TryFrom, TryInto};
+use zeroize::Zeroizing;
+
+impl TryFrom<OperationProto> for Operation {
+    type Error = ResponseStatus;
+
+    fn try_from(proto_op: OperationProto) -> std::result::Result<Self, Self::Error> {
+        let message = Zeroizing::new(proto_op.message);
+        let signature = Zeroizing::new(proto_op.signature);
+        Ok(Operation {
+            key_name: proto_op.key_name,
+            alg: proto_op
+                .alg
+                .ok_or_else(|| {
+                    error!("alg field of psa_verify_hash::Operation message is empty.");
+                    ResponseStatus::InvalidEncoding
+                })?
+                .try_into()?,
+            message,
+            signature,
+        })
+    }
+}
+
+impl TryFrom<Operation> for OperationProto {
+    type Error = ResponseStatus;
+
+    fn try_from(op: Operation) -> std::result::Result<Self, Self::Error> {
+        let alg = Some(op.alg.try_into()?);
+        Ok(OperationProto {
+            key_name: op.key_name,
+            alg,
+            message: op.hash.to_vec(),
+            signature: op.signature.to_vec(),
+        })
+    }
+}
+
+impl TryFrom<ResultProto> for Result {
+    type Error = ResponseStatus;
+
+    fn try_from(_proto_result: ResultProto) -> std::result::Result<Self, Self::Error> {
+        Ok(Result {})
+    }
+}
+
+impl TryFrom<Result> for ResultProto {
+    type Error = ResponseStatus;
+
+    fn try_from(_result: Result) -> std::result::Result<Self, Self::Error> {
+        Ok(ResultProto {})
+    }
+}

--- a/src/operations_protobuf/convert_psa_verify_message.rs
+++ b/src/operations_protobuf/convert_psa_verify_message.rs
@@ -1,6 +1,8 @@
 // Copyright 2019 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-use super::generated_ops::psa_verify_message::{Operation as OperationProto, Result as ResultProto};
+use super::generated_ops::psa_verify_message::{
+    Operation as OperationProto, Result as ResultProto,
+};
 use crate::operations::psa_verify_message::{Operation, Result};
 use crate::requests::ResponseStatus;
 use log::error;
@@ -36,7 +38,7 @@ impl TryFrom<Operation> for OperationProto {
         Ok(OperationProto {
             key_name: op.key_name,
             alg,
-            message: op.hash.to_vec(),
+            message: op.message.to_vec(),
             signature: op.signature.to_vec(),
         })
     }

--- a/src/operations_protobuf/convert_psa_verify_message.rs
+++ b/src/operations_protobuf/convert_psa_verify_message.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Contributors to the Parsec project.
+// Copyright 2021 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 use super::generated_ops::psa_verify_message::{
     Operation as OperationProto, Result as ResultProto,
@@ -57,5 +57,133 @@ impl TryFrom<Result> for ResultProto {
 
     fn try_from(_result: Result) -> std::result::Result<Self, Self::Error> {
         Ok(ResultProto {})
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::generated_ops::psa_algorithm as algorithm_proto;
+    use super::super::generated_ops::psa_verify_message::{
+        Operation as OperationProto, Result as ResultProto,
+    };
+    use super::super::{Convert, ProtobufConverter};
+    use crate::operations::psa_algorithm::AsymmetricSignature;
+    use crate::operations::psa_verify_message::{Operation, Result};
+    use crate::operations::{NativeOperation, NativeResult};
+    use crate::requests::{request::RequestBody, response::ResponseBody, Opcode};
+    use std::convert::TryInto;
+
+    static CONVERTER: ProtobufConverter = ProtobufConverter {};
+
+    #[test]
+    fn asym_proto_to_op() {
+        let mut proto: OperationProto = Default::default();
+        let hash = vec![0x11, 0x22, 0x33];
+        let key_name = "test name".to_string();
+        let signature = vec![0x11, 0x22, 0x33];
+        proto.message = hash.clone();
+        proto.alg = Some(algorithm_proto::algorithm::AsymmetricSignature {
+            variant: Some(
+                algorithm_proto::algorithm::asymmetric_signature::Variant::RsaPkcs1v15Sign(
+                    algorithm_proto::algorithm::asymmetric_signature::RsaPkcs1v15Sign {
+                        hash_alg: Some(algorithm_proto::algorithm::asymmetric_signature::SignHash {
+                            variant: Some(algorithm_proto::algorithm::asymmetric_signature::sign_hash::Variant::Specific(
+                                algorithm_proto::algorithm::Hash::Sha1.into(),
+                            )),
+                        }),
+                    },
+                ),
+            ),
+        });
+        proto.key_name = key_name.clone();
+        proto.signature = signature.clone();
+
+        let op: Operation = proto.try_into().expect("Failed to convert");
+
+        assert_eq!(op.message, hash.into());
+        assert_eq!(op.key_name, key_name);
+        assert_eq!(op.signature, signature.into());
+    }
+
+    #[test]
+    fn asym_op_to_proto() {
+        let hash = vec![0x11, 0x22, 0x33];
+        let key_name = "test name".to_string();
+        let signature = vec![0x11, 0x22, 0x33];
+
+        let op = Operation {
+            message: hash.clone().into(),
+            alg: AsymmetricSignature::RsaPkcs1v15SignRaw,
+            key_name: key_name.clone(),
+            signature: signature.clone().into(),
+        };
+
+        let proto: OperationProto = op.try_into().expect("Failed to convert");
+
+        assert_eq!(proto.message, hash);
+        assert_eq!(proto.key_name, key_name);
+        assert_eq!(proto.signature, signature);
+    }
+
+    #[test]
+    fn asym_proto_to_resp() {
+        let proto: ResultProto = Default::default();
+
+        let _result: Result = proto.try_into().expect("Failed to convert");
+    }
+
+    #[test]
+    fn asym_resp_to_proto() {
+        let result = Result {};
+
+        let _proto: ResultProto = result.try_into().expect("Failed to convert");
+    }
+
+    #[test]
+    fn op_asym_sign_e2e() {
+        let op = Operation {
+            message: vec![0x11, 0x22, 0x33].into(),
+            alg: AsymmetricSignature::RsaPkcs1v15SignRaw,
+            key_name: "test name".to_string(),
+            signature: vec![0x11, 0x22, 0x33].into(),
+        };
+        let body = CONVERTER
+            .operation_to_body(NativeOperation::PsaVerifyMessage(op))
+            .expect("Failed to convert request");
+
+        assert!(CONVERTER
+            .body_to_operation(body, Opcode::PsaVerifyMessage)
+            .is_ok());
+    }
+
+    #[test]
+    fn resp_asym_sign_e2e() {
+        let result = Result {};
+        let body = CONVERTER
+            .result_to_body(NativeResult::PsaVerifyMessage(result))
+            .expect("Failed to convert request");
+
+        assert!(CONVERTER
+            .body_to_result(body, Opcode::PsaVerifyMessage)
+            .is_ok());
+    }
+
+    #[test]
+    fn result_from_mangled_resp_body() {
+        let resp_body =
+            ResponseBody::from_bytes(vec![0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88]);
+        assert!(CONVERTER
+            .body_to_result(resp_body, Opcode::PsaVerifyMessage)
+            .is_err());
+    }
+
+    #[test]
+    fn op_from_mangled_req_body() {
+        let req_body =
+            RequestBody::from_bytes(vec![0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88]);
+
+        assert!(CONVERTER
+            .body_to_operation(req_body, Opcode::PsaVerifyMessage)
+            .is_err());
     }
 }

--- a/src/operations_protobuf/convert_psa_verify_message.rs
+++ b/src/operations_protobuf/convert_psa_verify_message.rs
@@ -20,7 +20,7 @@ impl TryFrom<OperationProto> for Operation {
             alg: proto_op
                 .alg
                 .ok_or_else(|| {
-                    error!("alg field of psa_verify_hash::Operation message is empty.");
+                    error!("alg field of psa_verify_message::Operation message is empty.");
                     ResponseStatus::InvalidEncoding
                 })?
                 .try_into()?,

--- a/src/operations_protobuf/generated_ops.rs
+++ b/src/operations_protobuf/generated_ops.rs
@@ -17,6 +17,8 @@ macro_rules! include_protobuf_as_module {
 
 include_protobuf_as_module!(psa_sign_hash);
 include_protobuf_as_module!(psa_verify_hash);
+include_protobuf_as_module!(psa_sign_message);
+include_protobuf_as_module!(psa_verify_message);
 include_protobuf_as_module!(psa_asymmetric_encrypt);
 include_protobuf_as_module!(psa_asymmetric_decrypt);
 include_protobuf_as_module!(psa_aead_encrypt);

--- a/src/operations_protobuf/generated_ops.rs
+++ b/src/operations_protobuf/generated_ops.rs
@@ -161,6 +161,7 @@ empty_clear_message!(psa_export_public_key::Operation);
 empty_clear_message!(psa_export_key::Operation);
 empty_clear_message!(psa_import_key::Result);
 empty_clear_message!(psa_verify_hash::Result);
+empty_clear_message!(psa_verify_message::Result);
 empty_clear_message!(psa_generate_random::Operation);
 empty_clear_message!(psa_hash_compare::Result);
 
@@ -179,6 +180,25 @@ impl ClearProtoMessage for psa_sign_hash::Result {
 impl ClearProtoMessage for psa_verify_hash::Operation {
     fn clear_message(&mut self) {
         self.hash.zeroize();
+        self.signature.zeroize();
+    }
+}
+
+impl ClearProtoMessage for psa_sign_message::Operation {
+    fn clear_message(&mut self) {
+        self.message.zeroize();
+    }
+}
+
+impl ClearProtoMessage for psa_sign_message::Result {
+    fn clear_message(&mut self) {
+        self.signature.zeroize();
+    }
+}
+
+impl ClearProtoMessage for psa_verify_message::Operation {
+    fn clear_message(&mut self) {
+        self.message.zeroize();
         self.signature.zeroize();
     }
 }

--- a/src/operations_protobuf/mod.rs
+++ b/src/operations_protobuf/mod.rs
@@ -59,8 +59,8 @@ use generated_ops::psa_hash_compute as psa_hash_compute_proto;
 use generated_ops::psa_import_key as psa_import_key_proto;
 use generated_ops::psa_raw_key_agreement as psa_raw_key_agreement_proto;
 use generated_ops::psa_sign_hash as psa_sign_hash_proto;
-use generated_ops::psa_verify_hash as psa_verify_hash_proto;
 use generated_ops::psa_sign_message as psa_sign_message_proto;
+use generated_ops::psa_verify_hash as psa_verify_hash_proto;
 use generated_ops::psa_verify_message as psa_verify_message_proto;
 use generated_ops::ClearProtoMessage;
 use prost::Message;
@@ -436,10 +436,9 @@ impl Convert for ProtobufConverter {
                 result,
                 psa_sign_message_proto::Result
             ))),
-            NativeResult::PsaVerifyMessage(result) => Ok(ResponseBody::from_bytes(native_to_wire!(
-                result,
-                psa_verify_message_proto::Result
-            ))),
+            NativeResult::PsaVerifyMessage(result) => Ok(ResponseBody::from_bytes(
+                native_to_wire!(result, psa_verify_message_proto::Result),
+            )),
             NativeResult::PsaAsymmetricEncrypt(result) => Ok(ResponseBody::from_bytes(
                 native_to_wire!(result, psa_asymmetric_encrypt_proto::Result),
             )),

--- a/src/operations_protobuf/mod.rs
+++ b/src/operations_protobuf/mod.rs
@@ -13,6 +13,8 @@ mod convert_psa_export_key;
 mod convert_psa_destroy_key;
 mod convert_psa_sign_hash;
 mod convert_psa_verify_hash;
+mod convert_psa_sign_message;
+mod convert_psa_verify_message;
 mod convert_psa_hash_compute;
 mod convert_psa_hash_compare;
 mod convert_list_providers;
@@ -58,6 +60,8 @@ use generated_ops::psa_import_key as psa_import_key_proto;
 use generated_ops::psa_raw_key_agreement as psa_raw_key_agreement_proto;
 use generated_ops::psa_sign_hash as psa_sign_hash_proto;
 use generated_ops::psa_verify_hash as psa_verify_hash_proto;
+use generated_ops::psa_sign_message as psa_sign_message_proto;
+use generated_ops::psa_verify_message as psa_verify_message_proto;
 use generated_ops::ClearProtoMessage;
 use prost::Message;
 use std::convert::TryInto;
@@ -153,6 +157,14 @@ impl Convert for ProtobufConverter {
                 body.bytes(),
                 psa_verify_hash_proto::Operation
             ))),
+            Opcode::PsaSignMessage => Ok(NativeOperation::PsaSignMessage(wire_to_native!(
+                body.bytes(),
+                psa_sign_message_proto::Operation
+            ))),
+            Opcode::PsaVerifyMessage => Ok(NativeOperation::PsaVerifyMessage(wire_to_native!(
+                body.bytes(),
+                psa_verify_message_proto::Operation
+            ))),
             Opcode::PsaAsymmetricEncrypt => Ok(NativeOperation::PsaAsymmetricEncrypt(
                 wire_to_native!(body.bytes(), psa_asymmetric_encrypt_proto::Operation),
             )),
@@ -231,6 +243,12 @@ impl Convert for ProtobufConverter {
             )),
             NativeOperation::PsaVerifyHash(operation) => Ok(RequestBody::from_bytes(
                 native_to_wire!(operation, psa_verify_hash_proto::Operation),
+            )),
+            NativeOperation::PsaSignMessage(operation) => Ok(RequestBody::from_bytes(
+                native_to_wire!(operation, psa_sign_message_proto::Operation),
+            )),
+            NativeOperation::PsaVerifyMessage(operation) => Ok(RequestBody::from_bytes(
+                native_to_wire!(operation, psa_verify_message_proto::Operation),
             )),
             NativeOperation::PsaAsymmetricEncrypt(operation) => Ok(RequestBody::from_bytes(
                 native_to_wire!(operation, psa_asymmetric_encrypt_proto::Operation),
@@ -316,6 +334,14 @@ impl Convert for ProtobufConverter {
             Opcode::PsaVerifyHash => Ok(NativeResult::PsaVerifyHash(wire_to_native!(
                 body.bytes(),
                 psa_verify_hash_proto::Result
+            ))),
+            Opcode::PsaSignMessage => Ok(NativeResult::PsaSignMessage(wire_to_native!(
+                body.bytes(),
+                psa_sign_message_proto::Result
+            ))),
+            Opcode::PsaVerifyMessage => Ok(NativeResult::PsaVerifyMessage(wire_to_native!(
+                body.bytes(),
+                psa_verify_message_proto::Result
             ))),
             Opcode::PsaAsymmetricEncrypt => Ok(NativeResult::PsaAsymmetricEncrypt(
                 wire_to_native!(body.bytes(), psa_asymmetric_encrypt_proto::Result),
@@ -405,6 +431,14 @@ impl Convert for ProtobufConverter {
             NativeResult::PsaVerifyHash(result) => Ok(ResponseBody::from_bytes(native_to_wire!(
                 result,
                 psa_verify_hash_proto::Result
+            ))),
+            NativeResult::PsaSignMessage(result) => Ok(ResponseBody::from_bytes(native_to_wire!(
+                result,
+                psa_sign_message_proto::Result
+            ))),
+            NativeResult::PsaVerifyMessage(result) => Ok(ResponseBody::from_bytes(native_to_wire!(
+                result,
+                psa_verify_message_proto::Result
             ))),
             NativeResult::PsaAsymmetricEncrypt(result) => Ok(ResponseBody::from_bytes(
                 native_to_wire!(result, psa_asymmetric_encrypt_proto::Result),

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -123,6 +123,10 @@ pub enum Opcode {
     PsaAeadDecrypt = 0x0012,
     /// PsaRawKeyAgreement operation
     PsaRawKeyAgreement = 0x0013,
+    /// PsaSignMessage operation
+    PsaSignMessage = 0x0018,
+    /// PsaVerifyMessage operation
+    PsaVerifyMessage = 0x0019,
     /// ListKeys operation
     ListKeys = 0x001A,
     /// ListClients operation (admin operation)
@@ -147,6 +151,8 @@ impl Opcode {
             | Opcode::PsaDestroyKey
             | Opcode::PsaSignHash
             | Opcode::PsaVerifyHash
+            | Opcode::PsaSignMessage
+            | Opcode::PsaVerifyMessage
             | Opcode::PsaImportKey
             | Opcode::PsaExportPublicKey
             | Opcode::PsaAsymmetricEncrypt
@@ -175,6 +181,8 @@ impl Opcode {
             | Opcode::PsaDestroyKey
             | Opcode::PsaSignHash
             | Opcode::PsaVerifyHash
+            | Opcode::PsaSignMessage
+            | Opcode::PsaVerifyMessage
             | Opcode::PsaImportKey
             | Opcode::PsaExportPublicKey
             | Opcode::PsaAsymmetricEncrypt


### PR DESCRIPTION
Implementation of PsaSignMessage and PsaVerifyMessage operations.
It requires updated rust-psa-crypto with new functions to compile.