### PR TITLE
Bump prost crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["encoding"]
 edition = "2018"
 
 [build-dependencies]
-prost-build = "0.6.1"
+prost-build = "0.8.0"
 
 [dependencies]
 serde = { version = "1.0.115", features = ["derive"] }
@@ -19,7 +19,7 @@ bincode = "1.3.1"
 num-traits = "0.2.12"
 num-derive = "0.3.2"
 num = "0.3.0"
-prost = "0.6.1"
+prost = "0.8.0"
 arbitrary = { version = "0.4.6", features = ["derive"], optional = true }
 uuid = "0.8.1"
 log = "0.4.11"


### PR DESCRIPTION
This commit updates the prost* crate versions following the cargo-audit
report mentioning a vulnerability in prost-types.

Advisory can be seen [here](https://rustsec.org/advisories/RUSTSEC-2021-0073).

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>