### PR TITLE
Commit the generated Rust protobuf files in tree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["encoding"]
 edition = "2018"
 
 [build-dependencies]
-prost-build = "0.6.1"
+prost-build = { version = "0.6.1", optional = true }
 
 [dependencies]
 serde = { version = "1.0.115", features = ["derive"] }
@@ -31,3 +31,4 @@ derivative = "2.1.1"
 [features]
 testing = []
 fuzz = ["arbitrary"]
+regenerate-protobuf = ["prost-build"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ trying to compile otherwise it will not work ("`No such file or directory`").
 $ git submodule update --init
 ```
 
+By default, the crate will use the pre-generated Rust Protobuf files in
+`src/operations_protobuf/generated_ops`. To re-generate them from the `parsec-operations`
+submodule, compile this
+crate with the feature `regenerate-protobuf`.
+
 ## License
 
 The software is provided under Apache-2.0. Contributions to this project are accepted under the same license.

--- a/src/operations_protobuf/generated_ops/delete_client.rs
+++ b/src/operations_protobuf/generated_ops/delete_client.rs
@@ -1,0 +1,8 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(string, tag="1")]
+    pub client: std::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+}

--- a/src/operations_protobuf/generated_ops/list_authenticators.rs
+++ b/src/operations_protobuf/generated_ops/list_authenticators.rs
@@ -1,0 +1,21 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AuthenticatorInfo {
+    #[prost(string, tag="1")]
+    pub description: std::string::String,
+    #[prost(uint32, tag="2")]
+    pub version_maj: u32,
+    #[prost(uint32, tag="3")]
+    pub version_min: u32,
+    #[prost(uint32, tag="4")]
+    pub version_rev: u32,
+    #[prost(uint32, tag="5")]
+    pub id: u32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+    #[prost(message, repeated, tag="1")]
+    pub authenticators: ::std::vec::Vec<AuthenticatorInfo>,
+}

--- a/src/operations_protobuf/generated_ops/list_clients.rs
+++ b/src/operations_protobuf/generated_ops/list_clients.rs
@@ -1,0 +1,8 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+    #[prost(string, repeated, tag="1")]
+    pub clients: ::std::vec::Vec<std::string::String>,
+}

--- a/src/operations_protobuf/generated_ops/list_keys.rs
+++ b/src/operations_protobuf/generated_ops/list_keys.rs
@@ -1,0 +1,17 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct KeyInfo {
+    #[prost(uint32, tag="1")]
+    pub provider_id: u32,
+    #[prost(string, tag="2")]
+    pub name: std::string::String,
+    #[prost(message, optional, tag="3")]
+    pub attributes: ::std::option::Option<super::psa_key_attributes::KeyAttributes>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+    #[prost(message, repeated, tag="1")]
+    pub keys: ::std::vec::Vec<KeyInfo>,
+}

--- a/src/operations_protobuf/generated_ops/list_opcodes.rs
+++ b/src/operations_protobuf/generated_ops/list_opcodes.rs
@@ -1,0 +1,10 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(uint32, tag="1")]
+    pub provider_id: u32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+    #[prost(uint32, repeated, tag="1")]
+    pub opcodes: ::std::vec::Vec<u32>,
+}

--- a/src/operations_protobuf/generated_ops/list_providers.rs
+++ b/src/operations_protobuf/generated_ops/list_providers.rs
@@ -1,0 +1,25 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ProviderInfo {
+    #[prost(string, tag="1")]
+    pub uuid: std::string::String,
+    #[prost(string, tag="2")]
+    pub description: std::string::String,
+    #[prost(string, tag="3")]
+    pub vendor: std::string::String,
+    #[prost(uint32, tag="4")]
+    pub version_maj: u32,
+    #[prost(uint32, tag="5")]
+    pub version_min: u32,
+    #[prost(uint32, tag="6")]
+    pub version_rev: u32,
+    #[prost(uint32, tag="7")]
+    pub id: u32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+    #[prost(message, repeated, tag="1")]
+    pub providers: ::std::vec::Vec<ProviderInfo>,
+}

--- a/src/operations_protobuf/generated_ops/mod.rs
+++ b/src/operations_protobuf/generated_ops/mod.rs
@@ -1,46 +1,34 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
-// Include the Rust generated file in its own module.
+
+pub mod psa_sign_hash;
+pub mod psa_verify_hash;
+pub mod psa_sign_message;
+pub mod psa_verify_message;
+pub mod psa_asymmetric_encrypt;
+pub mod psa_asymmetric_decrypt;
+pub mod psa_aead_encrypt;
+pub mod psa_aead_decrypt;
+pub mod psa_generate_key;
+pub mod psa_destroy_key;
+pub mod psa_export_public_key;
+pub mod psa_export_key;
+pub mod psa_import_key;
+pub mod list_opcodes;
+pub mod list_providers;
+pub mod list_authenticators;
+pub mod list_keys;
+pub mod list_clients;
+pub mod delete_client;
+pub mod ping;
+pub mod psa_key_attributes;
+pub mod psa_algorithm;
+pub mod psa_generate_random;
+pub mod psa_hash_compute;
+pub mod psa_hash_compare;
+pub mod psa_raw_key_agreement;
+
 use zeroize::Zeroize;
-
-macro_rules! include_protobuf_as_module {
-    ($name:ident) => {
-        pub mod $name {
-            #[allow(unused)]
-            #[macro_export]
-            use zeroize::Zeroize;
-            // The generated Rust file is in OUT_DIR, named $name.rs
-            include!(concat!(env!("OUT_DIR"), "/", stringify!($name), ".rs"));
-        }
-    };
-}
-
-include_protobuf_as_module!(psa_sign_hash);
-include_protobuf_as_module!(psa_verify_hash);
-include_protobuf_as_module!(psa_sign_message);
-include_protobuf_as_module!(psa_verify_message);
-include_protobuf_as_module!(psa_asymmetric_encrypt);
-include_protobuf_as_module!(psa_asymmetric_decrypt);
-include_protobuf_as_module!(psa_aead_encrypt);
-include_protobuf_as_module!(psa_aead_decrypt);
-include_protobuf_as_module!(psa_generate_key);
-include_protobuf_as_module!(psa_destroy_key);
-include_protobuf_as_module!(psa_export_public_key);
-include_protobuf_as_module!(psa_export_key);
-include_protobuf_as_module!(psa_import_key);
-include_protobuf_as_module!(list_opcodes);
-include_protobuf_as_module!(list_providers);
-include_protobuf_as_module!(list_authenticators);
-include_protobuf_as_module!(list_keys);
-include_protobuf_as_module!(list_clients);
-include_protobuf_as_module!(delete_client);
-include_protobuf_as_module!(ping);
-include_protobuf_as_module!(psa_key_attributes);
-include_protobuf_as_module!(psa_algorithm);
-include_protobuf_as_module!(psa_generate_random);
-include_protobuf_as_module!(psa_hash_compute);
-include_protobuf_as_module!(psa_hash_compare);
-include_protobuf_as_module!(psa_raw_key_agreement);
 
 use crate::requests::{ResponseStatus, Result};
 use log::error;

--- a/src/operations_protobuf/generated_ops/ping.rs
+++ b/src/operations_protobuf/generated_ops/ping.rs
@@ -1,0 +1,12 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+    /// Cast down to 8 bits
+    #[prost(uint32, tag="1")]
+    pub wire_protocol_version_maj: u32,
+    /// Cast down to 8 bits
+    #[prost(uint32, tag="2")]
+    pub wire_protocol_version_min: u32,
+}

--- a/src/operations_protobuf/generated_ops/psa_aead_decrypt.rs
+++ b/src/operations_protobuf/generated_ops/psa_aead_decrypt.rs
@@ -1,0 +1,18 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(string, tag="1")]
+    pub key_name: std::string::String,
+    #[prost(message, optional, tag="2")]
+    pub alg: ::std::option::Option<super::psa_algorithm::algorithm::Aead>,
+    #[prost(bytes, tag="3")]
+    pub nonce: std::vec::Vec<u8>,
+    #[prost(bytes, tag="4")]
+    pub additional_data: std::vec::Vec<u8>,
+    #[prost(bytes, tag="5")]
+    pub ciphertext: std::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+    #[prost(bytes, tag="1")]
+    pub plaintext: std::vec::Vec<u8>,
+}

--- a/src/operations_protobuf/generated_ops/psa_aead_encrypt.rs
+++ b/src/operations_protobuf/generated_ops/psa_aead_encrypt.rs
@@ -1,0 +1,18 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(string, tag="1")]
+    pub key_name: std::string::String,
+    #[prost(message, optional, tag="2")]
+    pub alg: ::std::option::Option<super::psa_algorithm::algorithm::Aead>,
+    #[prost(bytes, tag="3")]
+    pub nonce: std::vec::Vec<u8>,
+    #[prost(bytes, tag="4")]
+    pub additional_data: std::vec::Vec<u8>,
+    #[prost(bytes, tag="5")]
+    pub plaintext: std::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+    #[prost(bytes, tag="1")]
+    pub ciphertext: std::vec::Vec<u8>,
+}

--- a/src/operations_protobuf/generated_ops/psa_algorithm.rs
+++ b/src/operations_protobuf/generated_ops/psa_algorithm.rs
@@ -1,0 +1,291 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Algorithm {
+    #[prost(oneof="algorithm::Variant", tags="1, 2, 3, 4, 5, 6, 7, 8, 9")]
+    pub variant: ::std::option::Option<algorithm::Variant>,
+}
+pub mod algorithm {
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct None {
+    }
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Mac {
+        #[prost(oneof="mac::Variant", tags="1, 2")]
+        pub variant: ::std::option::Option<mac::Variant>,
+    }
+    pub mod mac {
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct FullLength {
+            #[prost(oneof="full_length::Variant", tags="1, 2, 3")]
+            pub variant: ::std::option::Option<full_length::Variant>,
+        }
+        pub mod full_length {
+            #[derive(Clone, PartialEq, ::prost::Message)]
+            pub struct Hmac {
+                #[prost(enumeration="super::super::Hash", tag="1")]
+                pub hash_alg: i32,
+            }
+            #[derive(Clone, PartialEq, ::prost::Message)]
+            pub struct CbcMac {
+            }
+            #[derive(Clone, PartialEq, ::prost::Message)]
+            pub struct Cmac {
+            }
+            #[derive(Clone, PartialEq, ::prost::Oneof)]
+            pub enum Variant {
+                #[prost(message, tag="1")]
+                Hmac(Hmac),
+                #[prost(message, tag="2")]
+                CbcMac(CbcMac),
+                #[prost(message, tag="3")]
+                Cmac(Cmac),
+            }
+        }
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct Truncated {
+            #[prost(message, optional, tag="1")]
+            pub mac_alg: ::std::option::Option<FullLength>,
+            #[prost(uint32, tag="2")]
+            pub mac_length: u32,
+        }
+        #[derive(Clone, PartialEq, ::prost::Oneof)]
+        pub enum Variant {
+            #[prost(message, tag="1")]
+            FullLength(FullLength),
+            #[prost(message, tag="2")]
+            Truncated(Truncated),
+        }
+    }
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Aead {
+        #[prost(oneof="aead::Variant", tags="1, 2")]
+        pub variant: ::std::option::Option<aead::Variant>,
+    }
+    pub mod aead {
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct AeadWithShortenedTag {
+            #[prost(enumeration="AeadWithDefaultLengthTag", tag="1")]
+            pub aead_alg: i32,
+            #[prost(uint32, tag="2")]
+            pub tag_length: u32,
+        }
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+        #[repr(i32)]
+        pub enum AeadWithDefaultLengthTag {
+            /// This default variant should not be used.
+            None = 0,
+            Ccm = 1,
+            Gcm = 2,
+            Chacha20Poly1305 = 3,
+        }
+        #[derive(Clone, PartialEq, ::prost::Oneof)]
+        pub enum Variant {
+            #[prost(enumeration="AeadWithDefaultLengthTag", tag="1")]
+            AeadWithDefaultLengthTag(i32),
+            #[prost(message, tag="2")]
+            AeadWithShortenedTag(AeadWithShortenedTag),
+        }
+    }
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct AsymmetricSignature {
+        #[prost(oneof="asymmetric_signature::Variant", tags="1, 2, 3, 4, 5, 6")]
+        pub variant: ::std::option::Option<asymmetric_signature::Variant>,
+    }
+    pub mod asymmetric_signature {
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct SignHash {
+            #[prost(oneof="sign_hash::Variant", tags="1, 2")]
+            pub variant: ::std::option::Option<sign_hash::Variant>,
+        }
+        pub mod sign_hash {
+            #[derive(Clone, PartialEq, ::prost::Message)]
+            pub struct Any {
+            }
+            #[derive(Clone, PartialEq, ::prost::Oneof)]
+            pub enum Variant {
+                #[prost(message, tag="1")]
+                Any(Any),
+                #[prost(enumeration="super::super::Hash", tag="2")]
+                Specific(i32),
+            }
+        }
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct RsaPkcs1v15Sign {
+            #[prost(message, optional, tag="1")]
+            pub hash_alg: ::std::option::Option<SignHash>,
+        }
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct RsaPkcs1v15SignRaw {
+        }
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct RsaPss {
+            #[prost(message, optional, tag="1")]
+            pub hash_alg: ::std::option::Option<SignHash>,
+        }
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct Ecdsa {
+            #[prost(message, optional, tag="1")]
+            pub hash_alg: ::std::option::Option<SignHash>,
+        }
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct EcdsaAny {
+        }
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct DeterministicEcdsa {
+            #[prost(message, optional, tag="1")]
+            pub hash_alg: ::std::option::Option<SignHash>,
+        }
+        #[derive(Clone, PartialEq, ::prost::Oneof)]
+        pub enum Variant {
+            #[prost(message, tag="1")]
+            RsaPkcs1v15Sign(RsaPkcs1v15Sign),
+            #[prost(message, tag="2")]
+            RsaPkcs1v15SignRaw(RsaPkcs1v15SignRaw),
+            #[prost(message, tag="3")]
+            RsaPss(RsaPss),
+            #[prost(message, tag="4")]
+            Ecdsa(Ecdsa),
+            #[prost(message, tag="5")]
+            EcdsaAny(EcdsaAny),
+            #[prost(message, tag="6")]
+            DeterministicEcdsa(DeterministicEcdsa),
+        }
+    }
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct AsymmetricEncryption {
+        #[prost(oneof="asymmetric_encryption::Variant", tags="1, 2")]
+        pub variant: ::std::option::Option<asymmetric_encryption::Variant>,
+    }
+    pub mod asymmetric_encryption {
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct RsaPkcs1v15Crypt {
+        }
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct RsaOaep {
+            #[prost(enumeration="super::Hash", tag="1")]
+            pub hash_alg: i32,
+        }
+        #[derive(Clone, PartialEq, ::prost::Oneof)]
+        pub enum Variant {
+            #[prost(message, tag="1")]
+            RsaPkcs1v15Crypt(RsaPkcs1v15Crypt),
+            #[prost(message, tag="2")]
+            RsaOaep(RsaOaep),
+        }
+    }
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct KeyAgreement {
+        #[prost(oneof="key_agreement::Variant", tags="1, 2")]
+        pub variant: ::std::option::Option<key_agreement::Variant>,
+    }
+    pub mod key_agreement {
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct WithKeyDerivation {
+            #[prost(enumeration="Raw", tag="1")]
+            pub ka_alg: i32,
+            #[prost(message, optional, tag="2")]
+            pub kdf_alg: ::std::option::Option<super::KeyDerivation>,
+        }
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+        #[repr(i32)]
+        pub enum Raw {
+            /// This default variant should not be used.
+            None = 0,
+            Ffdh = 1,
+            Ecdh = 2,
+        }
+        #[derive(Clone, PartialEq, ::prost::Oneof)]
+        pub enum Variant {
+            #[prost(enumeration="Raw", tag="1")]
+            Raw(i32),
+            #[prost(message, tag="2")]
+            WithKeyDerivation(WithKeyDerivation),
+        }
+    }
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct KeyDerivation {
+        #[prost(oneof="key_derivation::Variant", tags="1, 2, 3")]
+        pub variant: ::std::option::Option<key_derivation::Variant>,
+    }
+    pub mod key_derivation {
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct Hkdf {
+            #[prost(enumeration="super::Hash", tag="1")]
+            pub hash_alg: i32,
+        }
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct Tls12Prf {
+            #[prost(enumeration="super::Hash", tag="1")]
+            pub hash_alg: i32,
+        }
+        #[derive(Clone, PartialEq, ::prost::Message)]
+        pub struct Tls12PskToMs {
+            #[prost(enumeration="super::Hash", tag="1")]
+            pub hash_alg: i32,
+        }
+        #[derive(Clone, PartialEq, ::prost::Oneof)]
+        pub enum Variant {
+            #[prost(message, tag="1")]
+            Hkdf(Hkdf),
+            #[prost(message, tag="2")]
+            Tls12Prf(Tls12Prf),
+            #[prost(message, tag="3")]
+            Tls12PskToMs(Tls12PskToMs),
+        }
+    }
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum Hash {
+        /// This default variant should not be used.
+        None = 0,
+        Md2 = 1,
+        Md4 = 2,
+        Md5 = 3,
+        Ripemd160 = 4,
+        Sha1 = 5,
+        Sha224 = 6,
+        Sha256 = 7,
+        Sha384 = 8,
+        Sha512 = 9,
+        Sha512224 = 10,
+        Sha512256 = 11,
+        Sha3224 = 12,
+        Sha3256 = 13,
+        Sha3384 = 14,
+        Sha3512 = 15,
+    }
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum Cipher {
+        /// This default variant should not be used.
+        None = 0,
+        StreamCipher = 1,
+        Ctr = 2,
+        Cfb = 3,
+        Ofb = 4,
+        Xts = 5,
+        EcbNoPadding = 6,
+        CbcNoPadding = 7,
+        CbcPkcs7 = 8,
+    }
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Variant {
+        #[prost(message, tag="1")]
+        None(None),
+        #[prost(enumeration="Hash", tag="2")]
+        Hash(i32),
+        #[prost(message, tag="3")]
+        Mac(Mac),
+        #[prost(enumeration="Cipher", tag="4")]
+        Cipher(i32),
+        #[prost(message, tag="5")]
+        Aead(Aead),
+        #[prost(message, tag="6")]
+        AsymmetricSignature(AsymmetricSignature),
+        #[prost(message, tag="7")]
+        AsymmetricEncryption(AsymmetricEncryption),
+        #[prost(message, tag="8")]
+        KeyAgreement(KeyAgreement),
+        #[prost(message, tag="9")]
+        KeyDerivation(KeyDerivation),
+    }
+}

--- a/src/operations_protobuf/generated_ops/psa_asymmetric_decrypt.rs
+++ b/src/operations_protobuf/generated_ops/psa_asymmetric_decrypt.rs
@@ -1,0 +1,16 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(string, tag="1")]
+    pub key_name: std::string::String,
+    #[prost(message, optional, tag="2")]
+    pub alg: ::std::option::Option<super::psa_algorithm::algorithm::AsymmetricEncryption>,
+    #[prost(bytes, tag="3")]
+    pub ciphertext: std::vec::Vec<u8>,
+    #[prost(bytes, tag="4")]
+    pub salt: std::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+    #[prost(bytes, tag="1")]
+    pub plaintext: std::vec::Vec<u8>,
+}

--- a/src/operations_protobuf/generated_ops/psa_asymmetric_encrypt.rs
+++ b/src/operations_protobuf/generated_ops/psa_asymmetric_encrypt.rs
@@ -1,0 +1,16 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(string, tag="1")]
+    pub key_name: std::string::String,
+    #[prost(message, optional, tag="2")]
+    pub alg: ::std::option::Option<super::psa_algorithm::algorithm::AsymmetricEncryption>,
+    #[prost(bytes, tag="3")]
+    pub plaintext: std::vec::Vec<u8>,
+    #[prost(bytes, tag="4")]
+    pub salt: std::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+    #[prost(bytes, tag="1")]
+    pub ciphertext: std::vec::Vec<u8>,
+}

--- a/src/operations_protobuf/generated_ops/psa_cipher_decrypt.rs
+++ b/src/operations_protobuf/generated_ops/psa_cipher_decrypt.rs
@@ -1,0 +1,14 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(string, tag="1")]
+    pub key_name: std::string::String,
+    #[prost(enumeration="super::psa_algorithm::algorithm::Cipher", tag="2")]
+    pub alg: i32,
+    #[prost(bytes, tag="3")]
+    pub ciphertext: std::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+    #[prost(bytes, tag="1")]
+    pub plaintext: std::vec::Vec<u8>,
+}

--- a/src/operations_protobuf/generated_ops/psa_cipher_encrypt.rs
+++ b/src/operations_protobuf/generated_ops/psa_cipher_encrypt.rs
@@ -1,0 +1,14 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(string, tag="1")]
+    pub key_name: std::string::String,
+    #[prost(enumeration="super::psa_algorithm::algorithm::Cipher", tag="2")]
+    pub alg: i32,
+    #[prost(bytes, tag="3")]
+    pub plaintext: std::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+    #[prost(bytes, tag="1")]
+    pub ciphertext: std::vec::Vec<u8>,
+}

--- a/src/operations_protobuf/generated_ops/psa_destroy_key.rs
+++ b/src/operations_protobuf/generated_ops/psa_destroy_key.rs
@@ -1,0 +1,8 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(string, tag="1")]
+    pub key_name: std::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+}

--- a/src/operations_protobuf/generated_ops/psa_export_key.rs
+++ b/src/operations_protobuf/generated_ops/psa_export_key.rs
@@ -1,0 +1,10 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(string, tag="1")]
+    pub key_name: std::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+    #[prost(bytes, tag="1")]
+    pub data: std::vec::Vec<u8>,
+}

--- a/src/operations_protobuf/generated_ops/psa_export_public_key.rs
+++ b/src/operations_protobuf/generated_ops/psa_export_public_key.rs
@@ -1,0 +1,10 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(string, tag="1")]
+    pub key_name: std::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+    #[prost(bytes, tag="1")]
+    pub data: std::vec::Vec<u8>,
+}

--- a/src/operations_protobuf/generated_ops/psa_generate_key.rs
+++ b/src/operations_protobuf/generated_ops/psa_generate_key.rs
@@ -1,0 +1,10 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(string, tag="1")]
+    pub key_name: std::string::String,
+    #[prost(message, optional, tag="2")]
+    pub attributes: ::std::option::Option<super::psa_key_attributes::KeyAttributes>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+}

--- a/src/operations_protobuf/generated_ops/psa_generate_random.rs
+++ b/src/operations_protobuf/generated_ops/psa_generate_random.rs
@@ -1,0 +1,10 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(uint64, tag="1")]
+    pub size: u64,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+    #[prost(bytes, tag="1")]
+    pub random_bytes: std::vec::Vec<u8>,
+}

--- a/src/operations_protobuf/generated_ops/psa_hash_compare.rs
+++ b/src/operations_protobuf/generated_ops/psa_hash_compare.rs
@@ -1,0 +1,12 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(enumeration="super::psa_algorithm::algorithm::Hash", tag="1")]
+    pub alg: i32,
+    #[prost(bytes, tag="2")]
+    pub input: std::vec::Vec<u8>,
+    #[prost(bytes, tag="3")]
+    pub hash: std::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+}

--- a/src/operations_protobuf/generated_ops/psa_hash_compute.rs
+++ b/src/operations_protobuf/generated_ops/psa_hash_compute.rs
@@ -1,0 +1,12 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(enumeration="super::psa_algorithm::algorithm::Hash", tag="1")]
+    pub alg: i32,
+    #[prost(bytes, tag="2")]
+    pub input: std::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+    #[prost(bytes, tag="1")]
+    pub hash: std::vec::Vec<u8>,
+}

--- a/src/operations_protobuf/generated_ops/psa_import_key.rs
+++ b/src/operations_protobuf/generated_ops/psa_import_key.rs
@@ -1,0 +1,12 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(string, tag="1")]
+    pub key_name: std::string::String,
+    #[prost(message, optional, tag="2")]
+    pub attributes: ::std::option::Option<super::psa_key_attributes::KeyAttributes>,
+    #[prost(bytes, tag="3")]
+    pub data: std::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+}

--- a/src/operations_protobuf/generated_ops/psa_key_attributes.rs
+++ b/src/operations_protobuf/generated_ops/psa_key_attributes.rs
@@ -1,0 +1,154 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct KeyAttributes {
+    #[prost(message, optional, tag="1")]
+    pub key_type: ::std::option::Option<KeyType>,
+    #[prost(uint32, tag="2")]
+    pub key_bits: u32,
+    #[prost(message, optional, tag="3")]
+    pub key_policy: ::std::option::Option<KeyPolicy>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct KeyType {
+    #[prost(oneof="key_type::Variant", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14")]
+    pub variant: ::std::option::Option<key_type::Variant>,
+}
+pub mod key_type {
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct RawData {
+    }
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Hmac {
+    }
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Derive {
+    }
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Aes {
+    }
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Des {
+    }
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Camellia {
+    }
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Arc4 {
+    }
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Chacha20 {
+    }
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct RsaPublicKey {
+    }
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct RsaKeyPair {
+    }
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct EccKeyPair {
+        #[prost(enumeration="EccFamily", tag="1")]
+        pub curve_family: i32,
+    }
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct EccPublicKey {
+        #[prost(enumeration="EccFamily", tag="1")]
+        pub curve_family: i32,
+    }
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct DhKeyPair {
+        #[prost(enumeration="DhFamily", tag="1")]
+        pub group_family: i32,
+    }
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct DhPublicKey {
+        #[prost(enumeration="DhFamily", tag="1")]
+        pub group_family: i32,
+    }
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum EccFamily {
+        /// This default variant should not be used.
+        None = 0,
+        SecpK1 = 1,
+        SecpR1 = 2,
+        SecpR2 = 3,
+        /// DEPRECATED for sect163k1 curve
+        SectK1 = 4,
+        /// DEPRECATED for sect163r1 curve
+        SectR1 = 5,
+        SectR2 = 6,
+        /// DEPRECATED for brainpoolP160r1 curve
+        BrainpoolPR1 = 7,
+        Frp = 8,
+        Montgomery = 9,
+    }
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum DhFamily {
+        Rfc7919 = 0,
+    }
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Variant {
+        #[prost(message, tag="1")]
+        RawData(RawData),
+        /// Symmetric keys
+        #[prost(message, tag="2")]
+        Hmac(Hmac),
+        #[prost(message, tag="3")]
+        Derive(Derive),
+        #[prost(message, tag="4")]
+        Aes(Aes),
+        #[prost(message, tag="5")]
+        Des(Des),
+        #[prost(message, tag="6")]
+        Camellia(Camellia),
+        #[prost(message, tag="7")]
+        Arc4(Arc4),
+        #[prost(message, tag="8")]
+        Chacha20(Chacha20),
+        /// RSA keys
+        #[prost(message, tag="9")]
+        RsaPublicKey(RsaPublicKey),
+        #[prost(message, tag="10")]
+        RsaKeyPair(RsaKeyPair),
+        /// Elliptic Curve keys
+        #[prost(message, tag="11")]
+        EccKeyPair(EccKeyPair),
+        #[prost(message, tag="12")]
+        EccPublicKey(EccPublicKey),
+        /// Finite Field Diffie Hellman keys
+        #[prost(message, tag="13")]
+        DhKeyPair(DhKeyPair),
+        #[prost(message, tag="14")]
+        DhPublicKey(DhPublicKey),
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct KeyPolicy {
+    #[prost(message, optional, tag="1")]
+    pub key_usage_flags: ::std::option::Option<UsageFlags>,
+    #[prost(message, optional, tag="2")]
+    pub key_algorithm: ::std::option::Option<super::psa_algorithm::Algorithm>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UsageFlags {
+    #[prost(bool, tag="1")]
+    pub export: bool,
+    #[prost(bool, tag="2")]
+    pub copy: bool,
+    #[prost(bool, tag="3")]
+    pub cache: bool,
+    #[prost(bool, tag="4")]
+    pub encrypt: bool,
+    #[prost(bool, tag="5")]
+    pub decrypt: bool,
+    #[prost(bool, tag="6")]
+    pub sign_message: bool,
+    #[prost(bool, tag="7")]
+    pub verify_message: bool,
+    #[prost(bool, tag="8")]
+    pub sign_hash: bool,
+    #[prost(bool, tag="9")]
+    pub verify_hash: bool,
+    #[prost(bool, tag="10")]
+    pub derive: bool,
+}

--- a/src/operations_protobuf/generated_ops/psa_mac_compute.rs
+++ b/src/operations_protobuf/generated_ops/psa_mac_compute.rs
@@ -1,0 +1,14 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(string, tag="1")]
+    pub key_name: std::string::String,
+    #[prost(message, optional, tag="2")]
+    pub alg: ::std::option::Option<super::psa_algorithm::algorithm::Mac>,
+    #[prost(bytes, tag="3")]
+    pub input: std::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+    #[prost(bytes, tag="1")]
+    pub mac: std::vec::Vec<u8>,
+}

--- a/src/operations_protobuf/generated_ops/psa_mac_verify.rs
+++ b/src/operations_protobuf/generated_ops/psa_mac_verify.rs
@@ -1,0 +1,14 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(string, tag="1")]
+    pub key_name: std::string::String,
+    #[prost(message, optional, tag="2")]
+    pub alg: ::std::option::Option<super::psa_algorithm::algorithm::Mac>,
+    #[prost(bytes, tag="3")]
+    pub input: std::vec::Vec<u8>,
+    #[prost(bytes, tag="4")]
+    pub mac: std::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+}

--- a/src/operations_protobuf/generated_ops/psa_raw_key_agreement.rs
+++ b/src/operations_protobuf/generated_ops/psa_raw_key_agreement.rs
@@ -1,0 +1,14 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(enumeration="super::psa_algorithm::algorithm::key_agreement::Raw", tag="1")]
+    pub alg: i32,
+    #[prost(string, tag="2")]
+    pub private_key_name: std::string::String,
+    #[prost(bytes, tag="3")]
+    pub peer_key: std::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+    #[prost(bytes, tag="1")]
+    pub shared_secret: std::vec::Vec<u8>,
+}

--- a/src/operations_protobuf/generated_ops/psa_sign_hash.rs
+++ b/src/operations_protobuf/generated_ops/psa_sign_hash.rs
@@ -1,0 +1,14 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(string, tag="1")]
+    pub key_name: std::string::String,
+    #[prost(message, optional, tag="2")]
+    pub alg: ::std::option::Option<super::psa_algorithm::algorithm::AsymmetricSignature>,
+    #[prost(bytes, tag="3")]
+    pub hash: std::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+    #[prost(bytes, tag="1")]
+    pub signature: std::vec::Vec<u8>,
+}

--- a/src/operations_protobuf/generated_ops/psa_sign_message.rs
+++ b/src/operations_protobuf/generated_ops/psa_sign_message.rs
@@ -1,0 +1,14 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(string, tag="1")]
+    pub key_name: std::string::String,
+    #[prost(message, optional, tag="2")]
+    pub alg: ::std::option::Option<super::psa_algorithm::algorithm::AsymmetricSignature>,
+    #[prost(bytes, tag="3")]
+    pub message: std::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+    #[prost(bytes, tag="1")]
+    pub signature: std::vec::Vec<u8>,
+}

--- a/src/operations_protobuf/generated_ops/psa_verify_hash.rs
+++ b/src/operations_protobuf/generated_ops/psa_verify_hash.rs
@@ -1,0 +1,14 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(string, tag="1")]
+    pub key_name: std::string::String,
+    #[prost(message, optional, tag="2")]
+    pub alg: ::std::option::Option<super::psa_algorithm::algorithm::AsymmetricSignature>,
+    #[prost(bytes, tag="3")]
+    pub hash: std::vec::Vec<u8>,
+    #[prost(bytes, tag="4")]
+    pub signature: std::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+}

--- a/src/operations_protobuf/generated_ops/psa_verify_message.rs
+++ b/src/operations_protobuf/generated_ops/psa_verify_message.rs
@@ -1,0 +1,14 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(string, tag="1")]
+    pub key_name: std::string::String,
+    #[prost(message, optional, tag="2")]
+    pub alg: ::std::option::Option<super::psa_algorithm::algorithm::AsymmetricSignature>,
+    #[prost(bytes, tag="3")]
+    pub message: std::vec::Vec<u8>,
+    #[prost(bytes, tag="4")]
+    pub signature: std::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+}

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -19,6 +19,7 @@ git submodule update --init
 ##############
 RUST_BACKTRACE=1 cargo build
 RUST_BACKTRACE=1 cargo build --features testing
+RUST_BACKTRACE=1 cargo build --features regenerate-protobuf
 
 #################
 # Static checks #


### PR DESCRIPTION
That will speed-up the build process.

Fix #98

By default, 66 dependencies, 25.25 seconds.
With the feature (as it was before), 92 dependencies, 28.67 seconds.

edit: also removes the dependency on `protoc` for some targets (see https://parallaxsecond.github.io/parsec-book/parsec_service/build_run.html#dependencies)