### PR TITLE
Upgrade prost to 0.8.0

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,6 +1,5 @@
 [advisories]
-ignore = ["RUSTSEC-2021-0073", # We do not use `prost_types::Timestamp` anywhere in our code.
-          "RUSTSEC-2020-0036"] # We don't have control over the exact dependencies of `protoc-grpcio`; See https://github.com/mtp401/protoc-grpcio/issues/36
+ignore = []
 informational_warnings = ["unmaintained"] # warn for categories of informational advisories
 severity_threshold = "low" # CVSS severity ("none", "low", "medium", "high", "critical")
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["encoding"]
 edition = "2018"
 
 [build-dependencies]
-prost-build = { version = "0.6.1", optional = true }
+prost-build = { version = "0.8.0", optional = true }
 
 [dependencies]
 serde = { version = "1.0.115", features = ["derive"] }
@@ -19,7 +19,7 @@ bincode = "1.3.1"
 num-traits = "0.2.12"
 num-derive = "0.3.2"
 num = "0.3.0"
-prost = "0.6.1"
+prost = "0.8.0"
 arbitrary = { version = "0.4.6", features = ["derive"], optional = true }
 uuid = "0.8.1"
 log = "0.4.11"

--- a/src/operations_protobuf/generated_ops/delete_client.rs
+++ b/src/operations_protobuf/generated_ops/delete_client.rs
@@ -1,7 +1,7 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Operation {
     #[prost(string, tag="1")]
-    pub client: std::string::String,
+    pub client: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {

--- a/src/operations_protobuf/generated_ops/list_authenticators.rs
+++ b/src/operations_protobuf/generated_ops/list_authenticators.rs
@@ -1,7 +1,7 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AuthenticatorInfo {
     #[prost(string, tag="1")]
-    pub description: std::string::String,
+    pub description: ::prost::alloc::string::String,
     #[prost(uint32, tag="2")]
     pub version_maj: u32,
     #[prost(uint32, tag="3")]
@@ -17,5 +17,5 @@ pub struct Operation {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {
     #[prost(message, repeated, tag="1")]
-    pub authenticators: ::std::vec::Vec<AuthenticatorInfo>,
+    pub authenticators: ::prost::alloc::vec::Vec<AuthenticatorInfo>,
 }

--- a/src/operations_protobuf/generated_ops/list_clients.rs
+++ b/src/operations_protobuf/generated_ops/list_clients.rs
@@ -4,5 +4,5 @@ pub struct Operation {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {
     #[prost(string, repeated, tag="1")]
-    pub clients: ::std::vec::Vec<std::string::String>,
+    pub clients: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }

--- a/src/operations_protobuf/generated_ops/list_keys.rs
+++ b/src/operations_protobuf/generated_ops/list_keys.rs
@@ -3,9 +3,9 @@ pub struct KeyInfo {
     #[prost(uint32, tag="1")]
     pub provider_id: u32,
     #[prost(string, tag="2")]
-    pub name: std::string::String,
+    pub name: ::prost::alloc::string::String,
     #[prost(message, optional, tag="3")]
-    pub attributes: ::std::option::Option<super::psa_key_attributes::KeyAttributes>,
+    pub attributes: ::core::option::Option<super::psa_key_attributes::KeyAttributes>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Operation {
@@ -13,5 +13,5 @@ pub struct Operation {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {
     #[prost(message, repeated, tag="1")]
-    pub keys: ::std::vec::Vec<KeyInfo>,
+    pub keys: ::prost::alloc::vec::Vec<KeyInfo>,
 }

--- a/src/operations_protobuf/generated_ops/list_opcodes.rs
+++ b/src/operations_protobuf/generated_ops/list_opcodes.rs
@@ -6,5 +6,5 @@ pub struct Operation {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {
     #[prost(uint32, repeated, tag="1")]
-    pub opcodes: ::std::vec::Vec<u32>,
+    pub opcodes: ::prost::alloc::vec::Vec<u32>,
 }

--- a/src/operations_protobuf/generated_ops/list_providers.rs
+++ b/src/operations_protobuf/generated_ops/list_providers.rs
@@ -1,11 +1,11 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ProviderInfo {
     #[prost(string, tag="1")]
-    pub uuid: std::string::String,
+    pub uuid: ::prost::alloc::string::String,
     #[prost(string, tag="2")]
-    pub description: std::string::String,
+    pub description: ::prost::alloc::string::String,
     #[prost(string, tag="3")]
-    pub vendor: std::string::String,
+    pub vendor: ::prost::alloc::string::String,
     #[prost(uint32, tag="4")]
     pub version_maj: u32,
     #[prost(uint32, tag="5")]
@@ -21,5 +21,5 @@ pub struct Operation {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {
     #[prost(message, repeated, tag="1")]
-    pub providers: ::std::vec::Vec<ProviderInfo>,
+    pub providers: ::prost::alloc::vec::Vec<ProviderInfo>,
 }

--- a/src/operations_protobuf/generated_ops/psa_aead_decrypt.rs
+++ b/src/operations_protobuf/generated_ops/psa_aead_decrypt.rs
@@ -1,18 +1,18 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Operation {
     #[prost(string, tag="1")]
-    pub key_name: std::string::String,
+    pub key_name: ::prost::alloc::string::String,
     #[prost(message, optional, tag="2")]
-    pub alg: ::std::option::Option<super::psa_algorithm::algorithm::Aead>,
-    #[prost(bytes, tag="3")]
-    pub nonce: std::vec::Vec<u8>,
-    #[prost(bytes, tag="4")]
-    pub additional_data: std::vec::Vec<u8>,
-    #[prost(bytes, tag="5")]
-    pub ciphertext: std::vec::Vec<u8>,
+    pub alg: ::core::option::Option<super::psa_algorithm::algorithm::Aead>,
+    #[prost(bytes="vec", tag="3")]
+    pub nonce: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="4")]
+    pub additional_data: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="5")]
+    pub ciphertext: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {
-    #[prost(bytes, tag="1")]
-    pub plaintext: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="1")]
+    pub plaintext: ::prost::alloc::vec::Vec<u8>,
 }

--- a/src/operations_protobuf/generated_ops/psa_aead_encrypt.rs
+++ b/src/operations_protobuf/generated_ops/psa_aead_encrypt.rs
@@ -1,18 +1,18 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Operation {
     #[prost(string, tag="1")]
-    pub key_name: std::string::String,
+    pub key_name: ::prost::alloc::string::String,
     #[prost(message, optional, tag="2")]
-    pub alg: ::std::option::Option<super::psa_algorithm::algorithm::Aead>,
-    #[prost(bytes, tag="3")]
-    pub nonce: std::vec::Vec<u8>,
-    #[prost(bytes, tag="4")]
-    pub additional_data: std::vec::Vec<u8>,
-    #[prost(bytes, tag="5")]
-    pub plaintext: std::vec::Vec<u8>,
+    pub alg: ::core::option::Option<super::psa_algorithm::algorithm::Aead>,
+    #[prost(bytes="vec", tag="3")]
+    pub nonce: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="4")]
+    pub additional_data: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="5")]
+    pub plaintext: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {
-    #[prost(bytes, tag="1")]
-    pub ciphertext: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="1")]
+    pub ciphertext: ::prost::alloc::vec::Vec<u8>,
 }

--- a/src/operations_protobuf/generated_ops/psa_algorithm.rs
+++ b/src/operations_protobuf/generated_ops/psa_algorithm.rs
@@ -1,8 +1,9 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Algorithm {
     #[prost(oneof="algorithm::Variant", tags="1, 2, 3, 4, 5, 6, 7, 8, 9")]
-    pub variant: ::std::option::Option<algorithm::Variant>,
+    pub variant: ::core::option::Option<algorithm::Variant>,
 }
+/// Nested message and enum types in `Algorithm`.
 pub mod algorithm {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct None {
@@ -10,14 +11,16 @@ pub mod algorithm {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Mac {
         #[prost(oneof="mac::Variant", tags="1, 2")]
-        pub variant: ::std::option::Option<mac::Variant>,
+        pub variant: ::core::option::Option<mac::Variant>,
     }
+    /// Nested message and enum types in `Mac`.
     pub mod mac {
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct FullLength {
             #[prost(oneof="full_length::Variant", tags="1, 2, 3")]
-            pub variant: ::std::option::Option<full_length::Variant>,
+            pub variant: ::core::option::Option<full_length::Variant>,
         }
+        /// Nested message and enum types in `FullLength`.
         pub mod full_length {
             #[derive(Clone, PartialEq, ::prost::Message)]
             pub struct Hmac {
@@ -43,7 +46,7 @@ pub mod algorithm {
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct Truncated {
             #[prost(message, optional, tag="1")]
-            pub mac_alg: ::std::option::Option<FullLength>,
+            pub mac_alg: ::core::option::Option<FullLength>,
             #[prost(uint32, tag="2")]
             pub mac_length: u32,
         }
@@ -58,8 +61,9 @@ pub mod algorithm {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct Aead {
         #[prost(oneof="aead::Variant", tags="1, 2")]
-        pub variant: ::std::option::Option<aead::Variant>,
+        pub variant: ::core::option::Option<aead::Variant>,
     }
+    /// Nested message and enum types in `Aead`.
     pub mod aead {
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct AeadWithShortenedTag {
@@ -88,14 +92,16 @@ pub mod algorithm {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct AsymmetricSignature {
         #[prost(oneof="asymmetric_signature::Variant", tags="1, 2, 3, 4, 5, 6")]
-        pub variant: ::std::option::Option<asymmetric_signature::Variant>,
+        pub variant: ::core::option::Option<asymmetric_signature::Variant>,
     }
+    /// Nested message and enum types in `AsymmetricSignature`.
     pub mod asymmetric_signature {
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct SignHash {
             #[prost(oneof="sign_hash::Variant", tags="1, 2")]
-            pub variant: ::std::option::Option<sign_hash::Variant>,
+            pub variant: ::core::option::Option<sign_hash::Variant>,
         }
+        /// Nested message and enum types in `SignHash`.
         pub mod sign_hash {
             #[derive(Clone, PartialEq, ::prost::Message)]
             pub struct Any {
@@ -111,7 +117,7 @@ pub mod algorithm {
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct RsaPkcs1v15Sign {
             #[prost(message, optional, tag="1")]
-            pub hash_alg: ::std::option::Option<SignHash>,
+            pub hash_alg: ::core::option::Option<SignHash>,
         }
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct RsaPkcs1v15SignRaw {
@@ -119,12 +125,12 @@ pub mod algorithm {
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct RsaPss {
             #[prost(message, optional, tag="1")]
-            pub hash_alg: ::std::option::Option<SignHash>,
+            pub hash_alg: ::core::option::Option<SignHash>,
         }
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct Ecdsa {
             #[prost(message, optional, tag="1")]
-            pub hash_alg: ::std::option::Option<SignHash>,
+            pub hash_alg: ::core::option::Option<SignHash>,
         }
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct EcdsaAny {
@@ -132,7 +138,7 @@ pub mod algorithm {
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct DeterministicEcdsa {
             #[prost(message, optional, tag="1")]
-            pub hash_alg: ::std::option::Option<SignHash>,
+            pub hash_alg: ::core::option::Option<SignHash>,
         }
         #[derive(Clone, PartialEq, ::prost::Oneof)]
         pub enum Variant {
@@ -153,8 +159,9 @@ pub mod algorithm {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct AsymmetricEncryption {
         #[prost(oneof="asymmetric_encryption::Variant", tags="1, 2")]
-        pub variant: ::std::option::Option<asymmetric_encryption::Variant>,
+        pub variant: ::core::option::Option<asymmetric_encryption::Variant>,
     }
+    /// Nested message and enum types in `AsymmetricEncryption`.
     pub mod asymmetric_encryption {
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct RsaPkcs1v15Crypt {
@@ -175,15 +182,16 @@ pub mod algorithm {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct KeyAgreement {
         #[prost(oneof="key_agreement::Variant", tags="1, 2")]
-        pub variant: ::std::option::Option<key_agreement::Variant>,
+        pub variant: ::core::option::Option<key_agreement::Variant>,
     }
+    /// Nested message and enum types in `KeyAgreement`.
     pub mod key_agreement {
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct WithKeyDerivation {
             #[prost(enumeration="Raw", tag="1")]
             pub ka_alg: i32,
             #[prost(message, optional, tag="2")]
-            pub kdf_alg: ::std::option::Option<super::KeyDerivation>,
+            pub kdf_alg: ::core::option::Option<super::KeyDerivation>,
         }
         #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
         #[repr(i32)]
@@ -204,8 +212,9 @@ pub mod algorithm {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct KeyDerivation {
         #[prost(oneof="key_derivation::Variant", tags="1, 2, 3")]
-        pub variant: ::std::option::Option<key_derivation::Variant>,
+        pub variant: ::core::option::Option<key_derivation::Variant>,
     }
+    /// Nested message and enum types in `KeyDerivation`.
     pub mod key_derivation {
         #[derive(Clone, PartialEq, ::prost::Message)]
         pub struct Hkdf {

--- a/src/operations_protobuf/generated_ops/psa_asymmetric_decrypt.rs
+++ b/src/operations_protobuf/generated_ops/psa_asymmetric_decrypt.rs
@@ -1,16 +1,16 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Operation {
     #[prost(string, tag="1")]
-    pub key_name: std::string::String,
+    pub key_name: ::prost::alloc::string::String,
     #[prost(message, optional, tag="2")]
-    pub alg: ::std::option::Option<super::psa_algorithm::algorithm::AsymmetricEncryption>,
-    #[prost(bytes, tag="3")]
-    pub ciphertext: std::vec::Vec<u8>,
-    #[prost(bytes, tag="4")]
-    pub salt: std::vec::Vec<u8>,
+    pub alg: ::core::option::Option<super::psa_algorithm::algorithm::AsymmetricEncryption>,
+    #[prost(bytes="vec", tag="3")]
+    pub ciphertext: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="4")]
+    pub salt: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {
-    #[prost(bytes, tag="1")]
-    pub plaintext: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="1")]
+    pub plaintext: ::prost::alloc::vec::Vec<u8>,
 }

--- a/src/operations_protobuf/generated_ops/psa_asymmetric_encrypt.rs
+++ b/src/operations_protobuf/generated_ops/psa_asymmetric_encrypt.rs
@@ -1,16 +1,16 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Operation {
     #[prost(string, tag="1")]
-    pub key_name: std::string::String,
+    pub key_name: ::prost::alloc::string::String,
     #[prost(message, optional, tag="2")]
-    pub alg: ::std::option::Option<super::psa_algorithm::algorithm::AsymmetricEncryption>,
-    #[prost(bytes, tag="3")]
-    pub plaintext: std::vec::Vec<u8>,
-    #[prost(bytes, tag="4")]
-    pub salt: std::vec::Vec<u8>,
+    pub alg: ::core::option::Option<super::psa_algorithm::algorithm::AsymmetricEncryption>,
+    #[prost(bytes="vec", tag="3")]
+    pub plaintext: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="4")]
+    pub salt: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {
-    #[prost(bytes, tag="1")]
-    pub ciphertext: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="1")]
+    pub ciphertext: ::prost::alloc::vec::Vec<u8>,
 }

--- a/src/operations_protobuf/generated_ops/psa_cipher_decrypt.rs
+++ b/src/operations_protobuf/generated_ops/psa_cipher_decrypt.rs
@@ -1,14 +1,14 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Operation {
     #[prost(string, tag="1")]
-    pub key_name: std::string::String,
+    pub key_name: ::prost::alloc::string::String,
     #[prost(enumeration="super::psa_algorithm::algorithm::Cipher", tag="2")]
     pub alg: i32,
-    #[prost(bytes, tag="3")]
-    pub ciphertext: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="3")]
+    pub ciphertext: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {
-    #[prost(bytes, tag="1")]
-    pub plaintext: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="1")]
+    pub plaintext: ::prost::alloc::vec::Vec<u8>,
 }

--- a/src/operations_protobuf/generated_ops/psa_cipher_encrypt.rs
+++ b/src/operations_protobuf/generated_ops/psa_cipher_encrypt.rs
@@ -1,14 +1,14 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Operation {
     #[prost(string, tag="1")]
-    pub key_name: std::string::String,
+    pub key_name: ::prost::alloc::string::String,
     #[prost(enumeration="super::psa_algorithm::algorithm::Cipher", tag="2")]
     pub alg: i32,
-    #[prost(bytes, tag="3")]
-    pub plaintext: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="3")]
+    pub plaintext: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {
-    #[prost(bytes, tag="1")]
-    pub ciphertext: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="1")]
+    pub ciphertext: ::prost::alloc::vec::Vec<u8>,
 }

--- a/src/operations_protobuf/generated_ops/psa_destroy_key.rs
+++ b/src/operations_protobuf/generated_ops/psa_destroy_key.rs
@@ -1,7 +1,7 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Operation {
     #[prost(string, tag="1")]
-    pub key_name: std::string::String,
+    pub key_name: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {

--- a/src/operations_protobuf/generated_ops/psa_export_key.rs
+++ b/src/operations_protobuf/generated_ops/psa_export_key.rs
@@ -1,10 +1,10 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Operation {
     #[prost(string, tag="1")]
-    pub key_name: std::string::String,
+    pub key_name: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {
-    #[prost(bytes, tag="1")]
-    pub data: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="1")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
 }

--- a/src/operations_protobuf/generated_ops/psa_export_public_key.rs
+++ b/src/operations_protobuf/generated_ops/psa_export_public_key.rs
@@ -1,10 +1,10 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Operation {
     #[prost(string, tag="1")]
-    pub key_name: std::string::String,
+    pub key_name: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {
-    #[prost(bytes, tag="1")]
-    pub data: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="1")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
 }

--- a/src/operations_protobuf/generated_ops/psa_generate_key.rs
+++ b/src/operations_protobuf/generated_ops/psa_generate_key.rs
@@ -1,9 +1,9 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Operation {
     #[prost(string, tag="1")]
-    pub key_name: std::string::String,
+    pub key_name: ::prost::alloc::string::String,
     #[prost(message, optional, tag="2")]
-    pub attributes: ::std::option::Option<super::psa_key_attributes::KeyAttributes>,
+    pub attributes: ::core::option::Option<super::psa_key_attributes::KeyAttributes>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {

--- a/src/operations_protobuf/generated_ops/psa_generate_random.rs
+++ b/src/operations_protobuf/generated_ops/psa_generate_random.rs
@@ -5,6 +5,6 @@ pub struct Operation {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {
-    #[prost(bytes, tag="1")]
-    pub random_bytes: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="1")]
+    pub random_bytes: ::prost::alloc::vec::Vec<u8>,
 }

--- a/src/operations_protobuf/generated_ops/psa_hash_compare.rs
+++ b/src/operations_protobuf/generated_ops/psa_hash_compare.rs
@@ -2,10 +2,10 @@
 pub struct Operation {
     #[prost(enumeration="super::psa_algorithm::algorithm::Hash", tag="1")]
     pub alg: i32,
-    #[prost(bytes, tag="2")]
-    pub input: std::vec::Vec<u8>,
-    #[prost(bytes, tag="3")]
-    pub hash: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="2")]
+    pub input: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="3")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {

--- a/src/operations_protobuf/generated_ops/psa_hash_compute.rs
+++ b/src/operations_protobuf/generated_ops/psa_hash_compute.rs
@@ -2,11 +2,11 @@
 pub struct Operation {
     #[prost(enumeration="super::psa_algorithm::algorithm::Hash", tag="1")]
     pub alg: i32,
-    #[prost(bytes, tag="2")]
-    pub input: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="2")]
+    pub input: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {
-    #[prost(bytes, tag="1")]
-    pub hash: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="1")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
 }

--- a/src/operations_protobuf/generated_ops/psa_import_key.rs
+++ b/src/operations_protobuf/generated_ops/psa_import_key.rs
@@ -1,11 +1,11 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Operation {
     #[prost(string, tag="1")]
-    pub key_name: std::string::String,
+    pub key_name: ::prost::alloc::string::String,
     #[prost(message, optional, tag="2")]
-    pub attributes: ::std::option::Option<super::psa_key_attributes::KeyAttributes>,
-    #[prost(bytes, tag="3")]
-    pub data: std::vec::Vec<u8>,
+    pub attributes: ::core::option::Option<super::psa_key_attributes::KeyAttributes>,
+    #[prost(bytes="vec", tag="3")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {

--- a/src/operations_protobuf/generated_ops/psa_key_attributes.rs
+++ b/src/operations_protobuf/generated_ops/psa_key_attributes.rs
@@ -1,17 +1,18 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct KeyAttributes {
     #[prost(message, optional, tag="1")]
-    pub key_type: ::std::option::Option<KeyType>,
+    pub key_type: ::core::option::Option<KeyType>,
     #[prost(uint32, tag="2")]
     pub key_bits: u32,
     #[prost(message, optional, tag="3")]
-    pub key_policy: ::std::option::Option<KeyPolicy>,
+    pub key_policy: ::core::option::Option<KeyPolicy>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct KeyType {
     #[prost(oneof="key_type::Variant", tags="1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14")]
-    pub variant: ::std::option::Option<key_type::Variant>,
+    pub variant: ::core::option::Option<key_type::Variant>,
 }
+/// Nested message and enum types in `KeyType`.
 pub mod key_type {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct RawData {
@@ -125,9 +126,9 @@ pub mod key_type {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct KeyPolicy {
     #[prost(message, optional, tag="1")]
-    pub key_usage_flags: ::std::option::Option<UsageFlags>,
+    pub key_usage_flags: ::core::option::Option<UsageFlags>,
     #[prost(message, optional, tag="2")]
-    pub key_algorithm: ::std::option::Option<super::psa_algorithm::Algorithm>,
+    pub key_algorithm: ::core::option::Option<super::psa_algorithm::Algorithm>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UsageFlags {

--- a/src/operations_protobuf/generated_ops/psa_mac_compute.rs
+++ b/src/operations_protobuf/generated_ops/psa_mac_compute.rs
@@ -1,14 +1,14 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Operation {
     #[prost(string, tag="1")]
-    pub key_name: std::string::String,
+    pub key_name: ::prost::alloc::string::String,
     #[prost(message, optional, tag="2")]
-    pub alg: ::std::option::Option<super::psa_algorithm::algorithm::Mac>,
-    #[prost(bytes, tag="3")]
-    pub input: std::vec::Vec<u8>,
+    pub alg: ::core::option::Option<super::psa_algorithm::algorithm::Mac>,
+    #[prost(bytes="vec", tag="3")]
+    pub input: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {
-    #[prost(bytes, tag="1")]
-    pub mac: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="1")]
+    pub mac: ::prost::alloc::vec::Vec<u8>,
 }

--- a/src/operations_protobuf/generated_ops/psa_mac_verify.rs
+++ b/src/operations_protobuf/generated_ops/psa_mac_verify.rs
@@ -1,13 +1,13 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Operation {
     #[prost(string, tag="1")]
-    pub key_name: std::string::String,
+    pub key_name: ::prost::alloc::string::String,
     #[prost(message, optional, tag="2")]
-    pub alg: ::std::option::Option<super::psa_algorithm::algorithm::Mac>,
-    #[prost(bytes, tag="3")]
-    pub input: std::vec::Vec<u8>,
-    #[prost(bytes, tag="4")]
-    pub mac: std::vec::Vec<u8>,
+    pub alg: ::core::option::Option<super::psa_algorithm::algorithm::Mac>,
+    #[prost(bytes="vec", tag="3")]
+    pub input: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="4")]
+    pub mac: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {

--- a/src/operations_protobuf/generated_ops/psa_raw_key_agreement.rs
+++ b/src/operations_protobuf/generated_ops/psa_raw_key_agreement.rs
@@ -3,12 +3,12 @@ pub struct Operation {
     #[prost(enumeration="super::psa_algorithm::algorithm::key_agreement::Raw", tag="1")]
     pub alg: i32,
     #[prost(string, tag="2")]
-    pub private_key_name: std::string::String,
-    #[prost(bytes, tag="3")]
-    pub peer_key: std::vec::Vec<u8>,
+    pub private_key_name: ::prost::alloc::string::String,
+    #[prost(bytes="vec", tag="3")]
+    pub peer_key: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {
-    #[prost(bytes, tag="1")]
-    pub shared_secret: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="1")]
+    pub shared_secret: ::prost::alloc::vec::Vec<u8>,
 }

--- a/src/operations_protobuf/generated_ops/psa_sign_hash.rs
+++ b/src/operations_protobuf/generated_ops/psa_sign_hash.rs
@@ -1,14 +1,14 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Operation {
     #[prost(string, tag="1")]
-    pub key_name: std::string::String,
+    pub key_name: ::prost::alloc::string::String,
     #[prost(message, optional, tag="2")]
-    pub alg: ::std::option::Option<super::psa_algorithm::algorithm::AsymmetricSignature>,
-    #[prost(bytes, tag="3")]
-    pub hash: std::vec::Vec<u8>,
+    pub alg: ::core::option::Option<super::psa_algorithm::algorithm::AsymmetricSignature>,
+    #[prost(bytes="vec", tag="3")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {
-    #[prost(bytes, tag="1")]
-    pub signature: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="1")]
+    pub signature: ::prost::alloc::vec::Vec<u8>,
 }

--- a/src/operations_protobuf/generated_ops/psa_sign_message.rs
+++ b/src/operations_protobuf/generated_ops/psa_sign_message.rs
@@ -1,14 +1,14 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Operation {
     #[prost(string, tag="1")]
-    pub key_name: std::string::String,
+    pub key_name: ::prost::alloc::string::String,
     #[prost(message, optional, tag="2")]
-    pub alg: ::std::option::Option<super::psa_algorithm::algorithm::AsymmetricSignature>,
-    #[prost(bytes, tag="3")]
-    pub message: std::vec::Vec<u8>,
+    pub alg: ::core::option::Option<super::psa_algorithm::algorithm::AsymmetricSignature>,
+    #[prost(bytes="vec", tag="3")]
+    pub message: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {
-    #[prost(bytes, tag="1")]
-    pub signature: std::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="1")]
+    pub signature: ::prost::alloc::vec::Vec<u8>,
 }

--- a/src/operations_protobuf/generated_ops/psa_verify_hash.rs
+++ b/src/operations_protobuf/generated_ops/psa_verify_hash.rs
@@ -1,13 +1,13 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Operation {
     #[prost(string, tag="1")]
-    pub key_name: std::string::String,
+    pub key_name: ::prost::alloc::string::String,
     #[prost(message, optional, tag="2")]
-    pub alg: ::std::option::Option<super::psa_algorithm::algorithm::AsymmetricSignature>,
-    #[prost(bytes, tag="3")]
-    pub hash: std::vec::Vec<u8>,
-    #[prost(bytes, tag="4")]
-    pub signature: std::vec::Vec<u8>,
+    pub alg: ::core::option::Option<super::psa_algorithm::algorithm::AsymmetricSignature>,
+    #[prost(bytes="vec", tag="3")]
+    pub hash: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="4")]
+    pub signature: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {

--- a/src/operations_protobuf/generated_ops/psa_verify_message.rs
+++ b/src/operations_protobuf/generated_ops/psa_verify_message.rs
@@ -1,13 +1,13 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Operation {
     #[prost(string, tag="1")]
-    pub key_name: std::string::String,
+    pub key_name: ::prost::alloc::string::String,
     #[prost(message, optional, tag="2")]
-    pub alg: ::std::option::Option<super::psa_algorithm::algorithm::AsymmetricSignature>,
-    #[prost(bytes, tag="3")]
-    pub message: std::vec::Vec<u8>,
-    #[prost(bytes, tag="4")]
-    pub signature: std::vec::Vec<u8>,
+    pub alg: ::core::option::Option<super::psa_algorithm::algorithm::AsymmetricSignature>,
+    #[prost(bytes="vec", tag="3")]
+    pub message: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes="vec", tag="4")]
+    pub signature: ::prost::alloc::vec::Vec<u8>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Result {


### PR DESCRIPTION
This is to make our crates compile with the latest nightly Rust version.
Also performs a `cargo update` and regenerate the Protobuf files with
the latest version.

See https://github.com/parallaxsecond/parsec/issues/514