### PR TITLE
Add key attestation operations

### DIFF
--- a/src/operations/attest_key.rs
+++ b/src/operations/attest_key.rs
@@ -1,0 +1,41 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+//! # AttestKey operation
+//!
+//! Produce an attestation token as proof that the given
+//! key was produced and is stored in the hardware backend.
+use derivative::Derivative;
+use zeroize::Zeroizing;
+
+/// Native operation for key attestation
+#[derive(Derivative)]
+#[derivative(Debug)]
+#[non_exhaustive]
+pub enum Operation {
+    /// Attestation via TPM 2.0 ActivateCredential operation
+    ActivateCredential {
+        /// Name of key to be attested
+        attested_key_name: String,
+        /// Blob of data representing the encrypted credential
+        #[derivative(Debug = "ignore")]
+        credential_blob: Zeroizing<Vec<u8>>,
+        /// Blob of data representing the encrypted secret
+        #[derivative(Debug = "ignore")]
+        secret: Zeroizing<Vec<u8>>,
+        /// Name of key to be used for attesting
+        attesting_key_name: Option<String>,
+    },
+}
+
+/// Native result of key attestation
+#[derive(Derivative)]
+#[derivative(Debug)]
+#[non_exhaustive]
+pub enum Result {
+    /// Result of attestation via TPM 2.0 ActivateCredential operation
+    ActivateCredential {
+        /// Decrypted credential
+        #[derivative(Debug = "ignore")]
+        credential: Zeroizing<Vec<u8>>,
+    },
+}

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -35,6 +35,8 @@ pub mod delete_client;
 pub mod list_clients;
 pub mod psa_generate_random;
 pub mod psa_raw_key_agreement;
+pub mod attest_key;
+pub mod prepare_key_attestation;
 
 pub use psa_crypto::types::algorithm as psa_algorithm;
 pub use psa_crypto::types::key as psa_key_attributes;
@@ -97,6 +99,10 @@ pub enum NativeOperation {
     PsaSignMessage(psa_sign_message::Operation),
     /// PsaVerifyMessage operation
     PsaVerifyMessage(psa_verify_message::Operation),
+    /// AttestKey operation
+    AttestKey(attest_key::Operation),
+    /// PrepareKeyAttestation operation
+    PrepareKeyAttestation(prepare_key_attestation::Operation),
 }
 
 impl NativeOperation {
@@ -129,6 +135,8 @@ impl NativeOperation {
             NativeOperation::PsaRawKeyAgreement(_) => Opcode::PsaRawKeyAgreement,
             NativeOperation::PsaSignMessage(_) => Opcode::PsaSignMessage,
             NativeOperation::PsaVerifyMessage(_) => Opcode::PsaVerifyMessage,
+            NativeOperation::AttestKey(_) => Opcode::AttestKey,
+            NativeOperation::PrepareKeyAttestation(_) => Opcode::PrepareKeyAttestation,
         }
     }
 }
@@ -189,6 +197,10 @@ pub enum NativeResult {
     PsaSignMessage(psa_sign_message::Result),
     /// PsaVerifyMessage result
     PsaVerifyMessage(psa_verify_message::Result),
+    /// AttestKey result
+    AttestKey(attest_key::Result),
+    /// AttestKey result
+    PrepareKeyAttestation(prepare_key_attestation::Result),
 }
 
 impl NativeResult {
@@ -221,6 +233,8 @@ impl NativeResult {
             NativeResult::PsaRawKeyAgreement(_) => Opcode::PsaRawKeyAgreement,
             NativeResult::PsaSignMessage(_) => Opcode::PsaSignMessage,
             NativeResult::PsaVerifyMessage(_) => Opcode::PsaVerifyMessage,
+            NativeResult::AttestKey(_) => Opcode::AttestKey,
+            NativeResult::PrepareKeyAttestation(_) => Opcode::PrepareKeyAttestation,
         }
     }
 }
@@ -393,19 +407,33 @@ impl From<psa_hash_compare::Operation> for NativeOperation {
         NativeOperation::PsaHashCompare(op)
     }
 }
+
 impl From<psa_raw_key_agreement::Operation> for NativeOperation {
     fn from(op: psa_raw_key_agreement::Operation) -> Self {
         NativeOperation::PsaRawKeyAgreement(op)
     }
 }
+
 impl From<psa_sign_message::Operation> for NativeOperation {
     fn from(op: psa_sign_message::Operation) -> Self {
         NativeOperation::PsaSignMessage(op)
     }
 }
+
 impl From<psa_verify_message::Operation> for NativeOperation {
     fn from(op: psa_verify_message::Operation) -> Self {
         NativeOperation::PsaVerifyMessage(op)
+    }
+}
+
+impl From<attest_key::Operation> for NativeOperation {
+    fn from(op: attest_key::Operation) -> Self {
+        NativeOperation::AttestKey(op)
+    }
+}
+impl From<prepare_key_attestation::Operation> for NativeOperation {
+    fn from(op: prepare_key_attestation::Operation) -> Self {
+        NativeOperation::PrepareKeyAttestation(op)
     }
 }
 
@@ -562,5 +590,17 @@ impl From<psa_sign_message::Result> for NativeResult {
 impl From<psa_verify_message::Result> for NativeResult {
     fn from(op: psa_verify_message::Result) -> Self {
         NativeResult::PsaVerifyMessage(op)
+    }
+}
+
+impl From<attest_key::Result> for NativeResult {
+    fn from(op: attest_key::Result) -> Self {
+        NativeResult::AttestKey(op)
+    }
+}
+
+impl From<prepare_key_attestation::Result> for NativeResult {
+    fn from(op: prepare_key_attestation::Result) -> Self {
+        NativeResult::PrepareKeyAttestation(op)
     }
 }

--- a/src/operations/prepare_key_attestation.rs
+++ b/src/operations/prepare_key_attestation.rs
@@ -1,0 +1,39 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+//! # PrepareKeyAttestation operation
+//!
+//! Produce any parameters required for the AttestKey operation
+use derivative::Derivative;
+use zeroize::Zeroizing;
+
+/// Native operation for retrieving key attestation parameters
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Operation {
+    /// Get parameters for TPM 2.0 ActivateCredential operation
+    ActivateCredential {
+        /// Name of key to be attested
+        attested_key_name: String,
+        /// Name of key to be used for attesting
+        attesting_key_name: Option<String>,
+    },
+}
+
+/// Native result of retrieving key attestation parameters
+#[derive(Derivative)]
+#[derivative(Debug)]
+#[non_exhaustive]
+pub enum Result {
+    /// Parameters for TPM 2.0 ActivateCredential operation
+    ActivateCredential {
+        /// TPM name of key to be attested
+        #[derivative(Debug = "ignore")]
+        name: Zeroizing<Vec<u8>>,
+        /// TPM public key parameters of object to be attested
+        #[derivative(Debug = "ignore")]
+        public: Zeroizing<Vec<u8>>,
+        /// Public part of attesting key
+        #[derivative(Debug = "ignore")]
+        attesting_key_pub: Zeroizing<Vec<u8>>,
+    },
+}

--- a/src/operations_protobuf/convert_attest_key.rs
+++ b/src/operations_protobuf/convert_attest_key.rs
@@ -1,0 +1,326 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use super::generated_ops::attest_key::{
+    attestation_mechanism_params, attestation_output, AttestationMechanismParams,
+    AttestationOutput, Operation as OperationProto, Result as ResultProto,
+};
+use crate::operations::attest_key::{Operation, Result};
+use crate::requests::ResponseStatus;
+use log::error;
+use std::convert::TryFrom;
+
+impl TryFrom<Operation> for OperationProto {
+    type Error = ResponseStatus;
+
+    fn try_from(op: Operation) -> std::result::Result<Self, Self::Error> {
+        match op {
+            Operation::ActivateCredential {
+                attested_key_name,
+                attesting_key_name,
+                credential_blob,
+                secret,
+            } => Ok(OperationProto {
+                attested_key_name,
+                attesting_key_name: attesting_key_name.unwrap_or_default(),
+                parameters: Some(AttestationMechanismParams {
+                    mechanism: Some(attestation_mechanism_params::Mechanism::ActivateCredential(
+                        attestation_mechanism_params::ActivateCredential {
+                            credential_blob: credential_blob.to_vec(),
+                            secret: secret.to_vec(),
+                        },
+                    )),
+                }),
+            }),
+        }
+    }
+}
+
+impl TryFrom<OperationProto> for Operation {
+    type Error = ResponseStatus;
+
+    fn try_from(proto_op: OperationProto) -> std::result::Result<Self, Self::Error> {
+        match proto_op.parameters {
+            Some(AttestationMechanismParams {
+                mechanism:
+                    Some(attestation_mechanism_params::Mechanism::ActivateCredential(
+                        attestation_mechanism_params::ActivateCredential {
+                            credential_blob,
+                            secret,
+                        },
+                    )),
+            }) => Ok(Operation::ActivateCredential {
+                attested_key_name: proto_op.attested_key_name,
+                attesting_key_name: if proto_op.attesting_key_name.is_empty() {
+                    None
+                } else {
+                    Some(proto_op.attesting_key_name)
+                },
+                credential_blob: credential_blob.into(),
+                secret: secret.into(),
+            }),
+            _ => {
+                error!("The encoding of the operation does not follow the expected pattern");
+                Err(ResponseStatus::InvalidEncoding)
+            }
+        }
+    }
+}
+
+impl TryFrom<Result> for ResultProto {
+    type Error = ResponseStatus;
+
+    fn try_from(op: Result) -> std::result::Result<Self, Self::Error> {
+        match op {
+            Result::ActivateCredential { credential } => Ok(ResultProto {
+                output: Some(AttestationOutput {
+                    mechanism: Some(attestation_output::Mechanism::ActivateCredential(
+                        attestation_output::ActivateCredential {
+                            credential: credential.to_vec(),
+                        },
+                    )),
+                }),
+            }),
+        }
+    }
+}
+
+impl TryFrom<ResultProto> for Result {
+    type Error = ResponseStatus;
+
+    fn try_from(proto_op: ResultProto) -> std::result::Result<Self, Self::Error> {
+        match proto_op {
+            ResultProto {
+                output:
+                    Some(AttestationOutput {
+                        mechanism:
+                            Some(attestation_output::Mechanism::ActivateCredential(
+                                attestation_output::ActivateCredential { credential },
+                            )),
+                    }),
+            } => Ok(Result::ActivateCredential {
+                credential: credential.into(),
+            }),
+            _ => {
+                error!("The encoding of the result does not follow the expected pattern");
+                Err(ResponseStatus::InvalidEncoding)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::generated_ops::attest_key::{
+        attestation_mechanism_params, attestation_output, AttestationMechanismParams,
+        AttestationOutput, Operation as OperationProto, Result as ResultProto,
+    };
+    use super::super::{Convert, ProtobufConverter};
+    use crate::operations::{
+        attest_key::Operation, attest_key::Result, NativeOperation, NativeResult,
+    };
+    use crate::requests::Opcode;
+    use std::convert::TryInto;
+
+    static CONVERTER: ProtobufConverter = ProtobufConverter {};
+
+    #[test]
+    fn attest_key_op_from_proto() {
+        let op_attested_key_name = String::from("attested key name");
+        let op_attesting_key_name = String::from("attesting key name");
+        let op_credential_blob = vec![0xaa; 32];
+        let op_secret = vec![0x11; 16];
+
+        let proto = OperationProto {
+            attested_key_name: op_attested_key_name.clone(),
+            attesting_key_name: op_attesting_key_name.clone(),
+            parameters: Some(AttestationMechanismParams {
+                mechanism: Some(attestation_mechanism_params::Mechanism::ActivateCredential(
+                    attestation_mechanism_params::ActivateCredential {
+                        credential_blob: op_credential_blob.clone(),
+                        secret: op_secret.clone(),
+                    },
+                )),
+            }),
+        };
+
+        let op: Operation = proto.try_into().expect("Failed conversion");
+        let Operation::ActivateCredential {
+            attested_key_name,
+            attesting_key_name,
+            credential_blob,
+            secret,
+        } = op;
+        assert_eq!(attested_key_name, op_attested_key_name);
+        assert_eq!(
+            attesting_key_name.unwrap_or_default(),
+            op_attesting_key_name
+        );
+        assert_eq!(credential_blob.to_vec(), op_credential_blob);
+        assert_eq!(secret.to_vec(), op_secret);
+    }
+
+    #[test]
+    fn attest_key_proto_no_attesting() {
+        let op_attested_key_name = String::from("attested key name");
+        let op_credential_blob = vec![0xaa; 32];
+        let op_secret = vec![0x11; 16];
+
+        let proto = OperationProto {
+            attested_key_name: op_attested_key_name,
+            attesting_key_name: String::new(),
+            parameters: Some(AttestationMechanismParams {
+                mechanism: Some(attestation_mechanism_params::Mechanism::ActivateCredential(
+                    attestation_mechanism_params::ActivateCredential {
+                        credential_blob: op_credential_blob,
+                        secret: op_secret,
+                    },
+                )),
+            }),
+        };
+
+        let op: Operation = proto.try_into().expect("Failed conversion");
+        let Operation::ActivateCredential {
+            attesting_key_name, ..
+        } = op;
+        assert!(attesting_key_name.is_none());
+    }
+
+    #[test]
+    fn attest_key_proto_from_op() {
+        let op_attested_key_name = String::from("attested key name");
+        let op_attesting_key_name = String::from("attesting key name");
+        let op_credential_blob = vec![0xaa; 32];
+        let op_secret = vec![0x11; 16];
+
+        let op = Operation::ActivateCredential {
+            attested_key_name: op_attested_key_name.clone(),
+            attesting_key_name: Some(op_attesting_key_name.clone()),
+            credential_blob: op_credential_blob.clone().into(),
+            secret: op_secret.clone().into(),
+        };
+
+        let proto: OperationProto = op.try_into().expect("Failed conversion");
+        if let OperationProto {
+            attested_key_name,
+            attesting_key_name,
+            parameters:
+                Some(AttestationMechanismParams {
+                    mechanism:
+                        Some(attestation_mechanism_params::Mechanism::ActivateCredential(
+                            attestation_mechanism_params::ActivateCredential {
+                                credential_blob,
+                                secret,
+                            },
+                        )),
+                }),
+        } = proto
+        {
+            assert_eq!(attested_key_name, op_attested_key_name);
+            assert_eq!(attesting_key_name, op_attesting_key_name);
+            assert_eq!(credential_blob, op_credential_blob);
+            assert_eq!(secret, op_secret);
+        }
+    }
+
+    #[test]
+    fn attest_key_op_no_attesting() {
+        let op_attested_key_name = String::from("attested key name");
+        let op_credential_blob = vec![0xaa; 32];
+        let op_secret = vec![0x11; 16];
+
+        let op = Operation::ActivateCredential {
+            attested_key_name: op_attested_key_name,
+            attesting_key_name: None,
+            credential_blob: op_credential_blob.into(),
+            secret: op_secret.into(),
+        };
+
+        let proto: OperationProto = op.try_into().expect("Failed conversion");
+        assert_eq!(proto.attesting_key_name, String::new());
+    }
+
+    #[test]
+    fn attest_key_op_e2e() {
+        let op_attested_key_name = String::from("attested key name");
+        let op_attesting_key_name = String::from("attesting key name");
+        let op_credential_blob = vec![0xaa; 32];
+        let op_secret = vec![0x11; 16];
+
+        let op = Operation::ActivateCredential {
+            attested_key_name: op_attested_key_name,
+            attesting_key_name: Some(op_attesting_key_name),
+            credential_blob: op_credential_blob.into(),
+            secret: op_secret.into(),
+        };
+
+        let body = CONVERTER
+            .operation_to_body(NativeOperation::AttestKey(op))
+            .expect("Failed to convert to body");
+
+        let _ = CONVERTER
+            .body_to_operation(body, Opcode::AttestKey)
+            .expect("Failed to convert to operation");
+    }
+
+    #[test]
+    fn attest_key_resp_from_proto() {
+        let resp_credential = vec![0xbb; 32];
+
+        let proto = ResultProto {
+            output: Some(AttestationOutput {
+                mechanism: Some(attestation_output::Mechanism::ActivateCredential(
+                    attestation_output::ActivateCredential {
+                        credential: resp_credential.clone(),
+                    },
+                )),
+            }),
+        };
+
+        let resp: Result = proto.try_into().expect("Failed conversion");
+
+        let Result::ActivateCredential { credential } = resp;
+
+        assert_eq!(credential.to_vec(), resp_credential);
+    }
+
+    #[test]
+    fn attest_key_resp_to_proto() {
+        let resp_credential = vec![0xbb; 32];
+
+        let resp = Result::ActivateCredential {
+            credential: resp_credential.clone().into(),
+        };
+
+        let proto: ResultProto = resp.try_into().expect("Failed conversion");
+
+        if let ResultProto {
+            output:
+                Some(AttestationOutput {
+                    mechanism:
+                        Some(attestation_output::Mechanism::ActivateCredential(
+                            attestation_output::ActivateCredential { credential },
+                        )),
+                }),
+        } = proto
+        {
+            assert_eq!(credential.to_vec(), resp_credential);
+        }
+    }
+
+    #[test]
+    fn attest_key_resp_e2e() {
+        let resp_credential = vec![0xbb; 32];
+
+        let resp = Result::ActivateCredential {
+            credential: resp_credential.into(),
+        };
+
+        let body = CONVERTER
+            .result_to_body(NativeResult::AttestKey(resp))
+            .expect("Failed to convert to body");
+
+        let _ = CONVERTER
+            .body_to_result(body, Opcode::AttestKey)
+            .expect("Failed to convert to operation");
+    }
+}

--- a/src/operations_protobuf/convert_prepare_key_attestation.rs
+++ b/src/operations_protobuf/convert_prepare_key_attestation.rs
@@ -1,0 +1,362 @@
+// Copyright 2021 Contributors to the Parsec project.
+// SPDX-License-Identifier: Apache-2.0
+use super::generated_ops::prepare_key_attestation::{
+    prepare_key_attestation_output, prepare_key_attestation_params, Operation as OperationProto,
+    PrepareKeyAttestationOutput, PrepareKeyAttestationParams, Result as ResultProto,
+};
+use crate::operations::prepare_key_attestation::{Operation, Result};
+use crate::requests::ResponseStatus;
+use log::error;
+use std::convert::TryFrom;
+
+impl TryFrom<Operation> for OperationProto {
+    type Error = ResponseStatus;
+
+    fn try_from(op: Operation) -> std::result::Result<Self, Self::Error> {
+        match op {
+            Operation::ActivateCredential {
+                attested_key_name,
+                attesting_key_name,
+            } => Ok(OperationProto {
+                parameters: Some(PrepareKeyAttestationParams {
+                    mechanism: Some(
+                        prepare_key_attestation_params::Mechanism::ActivateCredential(
+                            prepare_key_attestation_params::ActivateCredential {
+                                attested_key_name,
+                                attesting_key_name: attesting_key_name.unwrap_or_default(),
+                            },
+                        ),
+                    ),
+                }),
+            }),
+        }
+    }
+}
+
+impl TryFrom<OperationProto> for Operation {
+    type Error = ResponseStatus;
+
+    fn try_from(op: OperationProto) -> std::result::Result<Self, Self::Error> {
+        match op {
+            OperationProto {
+                parameters:
+                    Some(PrepareKeyAttestationParams {
+                        mechanism:
+                            Some(prepare_key_attestation_params::Mechanism::ActivateCredential(
+                                prepare_key_attestation_params::ActivateCredential {
+                                    attested_key_name,
+                                    attesting_key_name,
+                                },
+                            )),
+                    }),
+            } => Ok(Operation::ActivateCredential {
+                attested_key_name,
+                attesting_key_name: if attesting_key_name.is_empty() {
+                    None
+                } else {
+                    Some(attesting_key_name)
+                },
+            }),
+            _ => {
+                error!("The encoding of the operation does not follow the expected pattern");
+                Err(ResponseStatus::InvalidEncoding)
+            }
+        }
+    }
+}
+
+impl TryFrom<Result> for ResultProto {
+    type Error = ResponseStatus;
+
+    fn try_from(op: Result) -> std::result::Result<Self, Self::Error> {
+        match op {
+            Result::ActivateCredential {
+                name,
+                public,
+                attesting_key_pub,
+            } => Ok(ResultProto {
+                output: Some(PrepareKeyAttestationOutput {
+                    mechanism: Some(
+                        prepare_key_attestation_output::Mechanism::ActivateCredential(
+                            prepare_key_attestation_output::ActivateCredential {
+                                name: name.to_vec(),
+                                public: public.to_vec(),
+                                attesting_key_pub: attesting_key_pub.to_vec(),
+                            },
+                        ),
+                    ),
+                }),
+            }),
+        }
+    }
+}
+
+impl TryFrom<ResultProto> for Result {
+    type Error = ResponseStatus;
+
+    fn try_from(op: ResultProto) -> std::result::Result<Self, Self::Error> {
+        match op {
+            ResultProto {
+                output:
+                    Some(PrepareKeyAttestationOutput {
+                        mechanism:
+                            Some(prepare_key_attestation_output::Mechanism::ActivateCredential(
+                                prepare_key_attestation_output::ActivateCredential {
+                                    name,
+                                    public,
+                                    attesting_key_pub,
+                                },
+                            )),
+                    }),
+            } => Ok(Result::ActivateCredential {
+                name: name.into(),
+                public: public.into(),
+                attesting_key_pub: attesting_key_pub.into(),
+            }),
+            _ => {
+                error!("The encoding of the operation does not follow the expected pattern");
+                Err(ResponseStatus::InvalidEncoding)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::generated_ops::prepare_key_attestation::{
+        prepare_key_attestation_output, prepare_key_attestation_params,
+        Operation as OperationProto, PrepareKeyAttestationOutput, PrepareKeyAttestationParams,
+        Result as ResultProto,
+    };
+    use super::super::{Convert, ProtobufConverter};
+    use crate::operations::{
+        prepare_key_attestation::Operation, prepare_key_attestation::Result, NativeOperation,
+        NativeResult,
+    };
+    use crate::requests::Opcode;
+    use std::convert::TryInto;
+
+    static CONVERTER: ProtobufConverter = ProtobufConverter {};
+
+    #[test]
+    fn prepare_key_attestation_op_from_proto() {
+        let op_attested_key_name = String::from("attested key name");
+        let op_attesting_key_name = String::from("attesting key name");
+
+        let proto = OperationProto {
+            parameters: Some(PrepareKeyAttestationParams {
+                mechanism: Some(
+                    prepare_key_attestation_params::Mechanism::ActivateCredential(
+                        prepare_key_attestation_params::ActivateCredential {
+                            attested_key_name: op_attested_key_name.clone(),
+                            attesting_key_name: op_attesting_key_name.clone(),
+                        },
+                    ),
+                ),
+            }),
+        };
+
+        let op: Operation = proto.try_into().expect("Conversion failed");
+
+        let Operation::ActivateCredential {
+            attested_key_name,
+            attesting_key_name,
+        } = op;
+
+        assert_eq!(attested_key_name, op_attested_key_name);
+        assert_eq!(
+            attesting_key_name.expect("Attesting key name was empty"),
+            op_attesting_key_name
+        );
+    }
+
+    #[test]
+    fn prepare_key_attestation_proto_no_attesting() {
+        let op_attested_key_name = String::from("attested key name");
+
+        let proto = OperationProto {
+            parameters: Some(PrepareKeyAttestationParams {
+                mechanism: Some(
+                    prepare_key_attestation_params::Mechanism::ActivateCredential(
+                        prepare_key_attestation_params::ActivateCredential {
+                            attested_key_name: op_attested_key_name,
+                            attesting_key_name: String::new(),
+                        },
+                    ),
+                ),
+            }),
+        };
+
+        let op: Operation = proto.try_into().expect("Conversion failed");
+
+        let Operation::ActivateCredential {
+            attesting_key_name, ..
+        } = op;
+
+        assert!(attesting_key_name.is_none());
+    }
+
+    #[test]
+    fn prepare_key_attestation_op_to_proto() {
+        let op_attested_key_name = String::from("attested key name");
+        let op_attesting_key_name = String::from("attesting key name");
+
+        let op: Operation = Operation::ActivateCredential {
+            attested_key_name: op_attested_key_name.clone(),
+            attesting_key_name: Some(op_attesting_key_name.clone()),
+        };
+
+        let proto: OperationProto = op.try_into().expect("Conversion failed");
+
+        if let OperationProto {
+            parameters:
+                Some(PrepareKeyAttestationParams {
+                    mechanism:
+                        Some(prepare_key_attestation_params::Mechanism::ActivateCredential(
+                            prepare_key_attestation_params::ActivateCredential {
+                                attested_key_name,
+                                attesting_key_name,
+                            },
+                        )),
+                }),
+        } = proto
+        {
+            assert_eq!(attested_key_name, op_attested_key_name);
+            assert_eq!(attesting_key_name, op_attesting_key_name);
+        }
+    }
+
+    #[test]
+    fn prepare_key_attestation_op_no_attesting() {
+        let op_attested_key_name = String::from("attested key name");
+
+        let op: Operation = Operation::ActivateCredential {
+            attested_key_name: op_attested_key_name,
+            attesting_key_name: None,
+        };
+
+        let proto: OperationProto = op.try_into().expect("Conversion failed");
+
+        if let OperationProto {
+            parameters:
+                Some(PrepareKeyAttestationParams {
+                    mechanism:
+                        Some(prepare_key_attestation_params::Mechanism::ActivateCredential(
+                            prepare_key_attestation_params::ActivateCredential {
+                                attesting_key_name,
+                                ..
+                            },
+                        )),
+                }),
+        } = proto
+        {
+            assert_eq!(attesting_key_name, String::new());
+        }
+    }
+
+    #[test]
+    fn prepare_key_attestation_op_e2e() {
+        let op_attested_key_name = String::from("attested key name");
+        let op_attesting_key_name = String::from("attesting key name");
+
+        let op: Operation = Operation::ActivateCredential {
+            attested_key_name: op_attested_key_name,
+            attesting_key_name: Some(op_attesting_key_name),
+        };
+
+        let body = CONVERTER
+            .operation_to_body(NativeOperation::PrepareKeyAttestation(op))
+            .expect("Failed to convert to body");
+
+        let _ = CONVERTER
+            .body_to_operation(body, Opcode::PrepareKeyAttestation)
+            .expect("Failed to convert to operation");
+    }
+
+    #[test]
+    fn prepare_key_attestation_resp_to_proto() {
+        let resp_name = vec![0xff; 32];
+        let resp_public = vec![0xcc; 32];
+        let resp_attesting_key_pub = vec![0x22; 32];
+
+        let result = Result::ActivateCredential {
+            name: resp_name.clone().into(),
+            public: resp_public.clone().into(),
+            attesting_key_pub: resp_attesting_key_pub.clone().into(),
+        };
+
+        let proto: ResultProto = result.try_into().expect("Conversion failed");
+        if let ResultProto {
+            output:
+                Some(PrepareKeyAttestationOutput {
+                    mechanism:
+                        Some(prepare_key_attestation_output::Mechanism::ActivateCredential(
+                            prepare_key_attestation_output::ActivateCredential {
+                                name,
+                                public,
+                                attesting_key_pub,
+                            },
+                        )),
+                }),
+        } = proto
+        {
+            assert_eq!(name, resp_name);
+            assert_eq!(public, resp_public);
+            assert_eq!(attesting_key_pub, resp_attesting_key_pub);
+        }
+    }
+
+    #[test]
+    fn prepare_key_attestation_resp_from_proto() {
+        let resp_name = vec![0xff; 32];
+        let resp_public = vec![0xcc; 32];
+        let resp_attesting_key_pub = vec![0x22; 32];
+
+        let proto = ResultProto {
+            output: Some(PrepareKeyAttestationOutput {
+                mechanism: Some(
+                    prepare_key_attestation_output::Mechanism::ActivateCredential(
+                        prepare_key_attestation_output::ActivateCredential {
+                            name: resp_name.clone(),
+                            public: resp_public.clone(),
+                            attesting_key_pub: resp_attesting_key_pub.clone(),
+                        },
+                    ),
+                ),
+            }),
+        };
+
+        let result: Result = proto.try_into().expect("Conversion failed");
+
+        let Result::ActivateCredential {
+            name,
+            public,
+            attesting_key_pub,
+        } = result;
+
+        assert_eq!(name.to_vec(), resp_name);
+        assert_eq!(public.to_vec(), resp_public);
+        assert_eq!(attesting_key_pub.to_vec(), resp_attesting_key_pub);
+    }
+
+    #[test]
+    fn prepare_key_attestation_resp_e2e() {
+        let resp_name = vec![0xff; 32];
+        let resp_public = vec![0xcc; 32];
+        let resp_attesting_key_pub = vec![0x22; 32];
+
+        let result = Result::ActivateCredential {
+            name: resp_name.into(),
+            public: resp_public.into(),
+            attesting_key_pub: resp_attesting_key_pub.into(),
+        };
+
+        let body = CONVERTER
+            .result_to_body(NativeResult::PrepareKeyAttestation(result))
+            .expect("Failed to convert to body");
+
+        let _ = CONVERTER
+            .body_to_result(body, Opcode::PrepareKeyAttestation)
+            .expect("Failed to convert to operation");
+    }
+}

--- a/src/operations_protobuf/generated_ops/attest_key.rs
+++ b/src/operations_protobuf/generated_ops/attest_key.rs
@@ -1,0 +1,52 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AttestationMechanismParams {
+    #[prost(oneof="attestation_mechanism_params::Mechanism", tags="1")]
+    pub mechanism: ::core::option::Option<attestation_mechanism_params::Mechanism>,
+}
+/// Nested message and enum types in `AttestationMechanismParams`.
+pub mod attestation_mechanism_params {
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct ActivateCredential {
+        #[prost(bytes="vec", tag="1")]
+        pub credential_blob: ::prost::alloc::vec::Vec<u8>,
+        #[prost(bytes="vec", tag="2")]
+        pub secret: ::prost::alloc::vec::Vec<u8>,
+    }
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Mechanism {
+        #[prost(message, tag="1")]
+        ActivateCredential(ActivateCredential),
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(string, tag="1")]
+    pub attested_key_name: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="2")]
+    pub parameters: ::core::option::Option<AttestationMechanismParams>,
+    #[prost(string, tag="3")]
+    pub attesting_key_name: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AttestationOutput {
+    #[prost(oneof="attestation_output::Mechanism", tags="1")]
+    pub mechanism: ::core::option::Option<attestation_output::Mechanism>,
+}
+/// Nested message and enum types in `AttestationOutput`.
+pub mod attestation_output {
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct ActivateCredential {
+        #[prost(bytes="vec", tag="1")]
+        pub credential: ::prost::alloc::vec::Vec<u8>,
+    }
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Mechanism {
+        #[prost(message, tag="1")]
+        ActivateCredential(ActivateCredential),
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+    #[prost(message, optional, tag="1")]
+    pub output: ::core::option::Option<AttestationOutput>,
+}

--- a/src/operations_protobuf/generated_ops/mod.rs
+++ b/src/operations_protobuf/generated_ops/mod.rs
@@ -29,6 +29,8 @@ pub mod psa_generate_random;
 pub mod psa_hash_compute;
 pub mod psa_hash_compare;
 pub mod psa_raw_key_agreement;
+pub mod attest_key;
+pub mod prepare_key_attestation;
 
 use zeroize::Zeroize;
 
@@ -154,6 +156,7 @@ empty_clear_message!(psa_verify_hash::Result);
 empty_clear_message!(psa_verify_message::Result);
 empty_clear_message!(psa_generate_random::Operation);
 empty_clear_message!(psa_hash_compare::Result);
+empty_clear_message!(prepare_key_attestation::Operation);
 
 impl ClearProtoMessage for psa_sign_hash::Operation {
     fn clear_message(&mut self) {
@@ -226,11 +229,15 @@ impl ClearProtoMessage for psa_asymmetric_decrypt::Operation {
 }
 
 impl ClearProtoMessage for psa_asymmetric_encrypt::Result {
-    fn clear_message(&mut self) { self.ciphertext.zeroize(); }
+    fn clear_message(&mut self) {
+        self.ciphertext.zeroize();
+    }
 }
 
 impl ClearProtoMessage for psa_asymmetric_decrypt::Result {
-    fn clear_message(&mut self) { self.plaintext.zeroize(); }
+    fn clear_message(&mut self) {
+        self.plaintext.zeroize();
+    }
 }
 
 impl ClearProtoMessage for psa_aead_encrypt::Operation {
@@ -250,7 +257,9 @@ impl ClearProtoMessage for psa_aead_decrypt::Operation {
 }
 
 impl ClearProtoMessage for psa_aead_encrypt::Result {
-    fn clear_message(&mut self) { self.ciphertext.zeroize(); }
+    fn clear_message(&mut self) {
+        self.ciphertext.zeroize();
+    }
 }
 
 impl ClearProtoMessage for psa_aead_decrypt::Result {
@@ -280,15 +289,21 @@ impl ClearProtoMessage for psa_cipher_decrypt::Result {
 }
 
 impl ClearProtoMessage for psa_generate_random::Result {
-    fn clear_message(&mut self) { self.random_bytes.zeroize(); }
+    fn clear_message(&mut self) {
+        self.random_bytes.zeroize();
+    }
 }
 
 impl ClearProtoMessage for psa_hash_compute::Operation {
-    fn clear_message(&mut self) { self.input.zeroize(); }
+    fn clear_message(&mut self) {
+        self.input.zeroize();
+    }
 }
 
 impl ClearProtoMessage for psa_hash_compute::Result {
-    fn clear_message(&mut self) { self.hash.zeroize(); }
+    fn clear_message(&mut self) {
+        self.hash.zeroize();
+    }
 }
 
 impl ClearProtoMessage for psa_hash_compare::Operation {
@@ -310,12 +325,82 @@ impl ClearProtoMessage for psa_raw_key_agreement::Result {
     }
 }
 
+impl ClearProtoMessage for attest_key::Operation {
+    fn clear_message(&mut self) {
+        if let attest_key::Operation {
+            parameters:
+                Some(attest_key::AttestationMechanismParams {
+                    mechanism:
+                        Some(attest_key::attestation_mechanism_params::Mechanism::ActivateCredential(
+                            attest_key::attestation_mechanism_params::ActivateCredential {
+                                credential_blob,
+                                secret,
+                            },
+                        )),
+                }),
+            ..
+        } = self
+        {
+            credential_blob.zeroize();
+            secret.zeroize();
+        }
+    }
+}
+
+impl ClearProtoMessage for attest_key::Result {
+    fn clear_message(&mut self) {
+        if let attest_key::Result {
+            output:
+                Some(attest_key::AttestationOutput {
+                    mechanism:
+                        Some(attest_key::attestation_output::Mechanism::ActivateCredential(
+                            attest_key::attestation_output::ActivateCredential { credential },
+                        )),
+                }),
+        } = self
+        {
+            credential.zeroize();
+        }
+    }
+}
+
+impl ClearProtoMessage for prepare_key_attestation::Result {
+    fn clear_message(&mut self) {
+        if let prepare_key_attestation::Result { output: Some(prepare_key_attestation::PrepareKeyAttestationOutput {
+                mechanism: Some(prepare_key_attestation::prepare_key_attestation_output::Mechanism::ActivateCredential(
+                    prepare_key_attestation::prepare_key_attestation_output::ActivateCredential {
+                        name, public, attesting_key_pub
+                    }
+                ))
+            })
+            } = self {
+                name.zeroize();
+                public.zeroize();
+                attesting_key_pub.zeroize();
+            }
+    }
+}
+
 #[test]
 fn i32_conversions() {
-    assert_eq!(Cipher::try_from(56).unwrap_err(), ResponseStatus::InvalidEncoding);
-    assert_eq!(Cipher::try_from(-5).unwrap_err(), ResponseStatus::InvalidEncoding);
-    assert_eq!(Hash::try_from(89).unwrap_err(), ResponseStatus::InvalidEncoding);
-    assert_eq!(Hash::try_from(-4).unwrap_err(), ResponseStatus::InvalidEncoding);
-    assert_eq!(EccFamily::try_from(78).unwrap_err(), ResponseStatus::InvalidEncoding);
-
+    assert_eq!(
+        Cipher::try_from(56).unwrap_err(),
+        ResponseStatus::InvalidEncoding
+    );
+    assert_eq!(
+        Cipher::try_from(-5).unwrap_err(),
+        ResponseStatus::InvalidEncoding
+    );
+    assert_eq!(
+        Hash::try_from(89).unwrap_err(),
+        ResponseStatus::InvalidEncoding
+    );
+    assert_eq!(
+        Hash::try_from(-4).unwrap_err(),
+        ResponseStatus::InvalidEncoding
+    );
+    assert_eq!(
+        EccFamily::try_from(78).unwrap_err(),
+        ResponseStatus::InvalidEncoding
+    );
 }

--- a/src/operations_protobuf/generated_ops/prepare_key_attestation.rs
+++ b/src/operations_protobuf/generated_ops/prepare_key_attestation.rs
@@ -1,0 +1,52 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PrepareKeyAttestationParams {
+    #[prost(oneof="prepare_key_attestation_params::Mechanism", tags="1")]
+    pub mechanism: ::core::option::Option<prepare_key_attestation_params::Mechanism>,
+}
+/// Nested message and enum types in `PrepareKeyAttestationParams`.
+pub mod prepare_key_attestation_params {
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct ActivateCredential {
+        #[prost(string, tag="1")]
+        pub attested_key_name: ::prost::alloc::string::String,
+        #[prost(string, tag="2")]
+        pub attesting_key_name: ::prost::alloc::string::String,
+    }
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Mechanism {
+        #[prost(message, tag="1")]
+        ActivateCredential(ActivateCredential),
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Operation {
+    #[prost(message, optional, tag="1")]
+    pub parameters: ::core::option::Option<PrepareKeyAttestationParams>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PrepareKeyAttestationOutput {
+    #[prost(oneof="prepare_key_attestation_output::Mechanism", tags="1")]
+    pub mechanism: ::core::option::Option<prepare_key_attestation_output::Mechanism>,
+}
+/// Nested message and enum types in `PrepareKeyAttestationOutput`.
+pub mod prepare_key_attestation_output {
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct ActivateCredential {
+        #[prost(bytes="vec", tag="1")]
+        pub name: ::prost::alloc::vec::Vec<u8>,
+        #[prost(bytes="vec", tag="2")]
+        pub public: ::prost::alloc::vec::Vec<u8>,
+        #[prost(bytes="vec", tag="3")]
+        pub attesting_key_pub: ::prost::alloc::vec::Vec<u8>,
+    }
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Mechanism {
+        #[prost(message, tag="1")]
+        ActivateCredential(ActivateCredential),
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Result {
+    #[prost(message, optional, tag="1")]
+    pub output: ::core::option::Option<PrepareKeyAttestationOutput>,
+}

--- a/src/operations_protobuf/mod.rs
+++ b/src/operations_protobuf/mod.rs
@@ -31,6 +31,8 @@ mod convert_psa_cipher_encrypt;
 mod convert_psa_cipher_decrypt;
 mod convert_psa_generate_random;
 mod convert_psa_raw_key_agreement;
+mod convert_attest_key;
+mod convert_prepare_key_attestation;
 
 #[rustfmt::skip]
 #[allow(unused_qualifications, missing_copy_implementations, clippy::pedantic, clippy::module_inception, clippy::upper_case_acronyms, clippy::enum_variant_names)]
@@ -40,6 +42,7 @@ use crate::operations::{Convert, NativeOperation, NativeResult};
 use crate::requests::{
     request::RequestBody, response::ResponseBody, BodyType, Opcode, ResponseStatus, Result,
 };
+use generated_ops::attest_key as attest_key_proto;
 use generated_ops::delete_client as delete_client_proto;
 use generated_ops::list_authenticators as list_authenticators_proto;
 use generated_ops::list_clients as list_clients_proto;
@@ -47,6 +50,7 @@ use generated_ops::list_keys as list_keys_proto;
 use generated_ops::list_opcodes as list_opcodes_proto;
 use generated_ops::list_providers as list_providers_proto;
 use generated_ops::ping as ping_proto;
+use generated_ops::prepare_key_attestation as prepare_key_attestation_proto;
 use generated_ops::psa_aead_decrypt as psa_aead_decrypt_proto;
 use generated_ops::psa_aead_encrypt as psa_aead_encrypt_proto;
 use generated_ops::psa_asymmetric_decrypt as psa_asymmetric_decrypt_proto;
@@ -207,6 +211,13 @@ impl Convert for ProtobufConverter {
                 body.bytes(),
                 psa_raw_key_agreement_proto::Operation
             ))),
+            Opcode::AttestKey => Ok(NativeOperation::AttestKey(wire_to_native!(
+                body.bytes(),
+                attest_key_proto::Operation
+            ))),
+            Opcode::PrepareKeyAttestation => Ok(NativeOperation::PrepareKeyAttestation(
+                wire_to_native!(body.bytes(), prepare_key_attestation_proto::Operation),
+            )),
         }
     }
 
@@ -291,6 +302,13 @@ impl Convert for ProtobufConverter {
             )),
             NativeOperation::PsaRawKeyAgreement(operation) => Ok(RequestBody::from_bytes(
                 native_to_wire!(operation, psa_raw_key_agreement_proto::Operation),
+            )),
+            NativeOperation::AttestKey(operation) => Ok(RequestBody::from_bytes(native_to_wire!(
+                operation,
+                attest_key_proto::Operation
+            ))),
+            NativeOperation::PrepareKeyAttestation(operation) => Ok(RequestBody::from_bytes(
+                native_to_wire!(operation, prepare_key_attestation_proto::Operation),
             )),
         }
     }
@@ -399,6 +417,13 @@ impl Convert for ProtobufConverter {
                 body.bytes(),
                 psa_raw_key_agreement_proto::Result
             ))),
+            Opcode::AttestKey => Ok(NativeResult::AttestKey(wire_to_native!(
+                body.bytes(),
+                attest_key_proto::Result
+            ))),
+            Opcode::PrepareKeyAttestation => Ok(NativeResult::PrepareKeyAttestation(
+                wire_to_native!(body.bytes(), prepare_key_attestation_proto::Result),
+            )),
         }
     }
 
@@ -498,6 +523,13 @@ impl Convert for ProtobufConverter {
             ))),
             NativeResult::PsaRawKeyAgreement(result) => Ok(ResponseBody::from_bytes(
                 native_to_wire!(result, psa_raw_key_agreement_proto::Result),
+            )),
+            NativeResult::AttestKey(result) => Ok(ResponseBody::from_bytes(native_to_wire!(
+                result,
+                attest_key_proto::Result
+            ))),
+            NativeResult::PrepareKeyAttestation(result) => Ok(ResponseBody::from_bytes(
+                native_to_wire!(result, prepare_key_attestation_proto::Result),
             )),
         }
     }

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -137,6 +137,10 @@ pub enum Opcode {
     ListClients = 0x001B,
     /// DeleteClient operation (admin operation)
     DeleteClient = 0x001C,
+    /// AttestKey operation
+    AttestKey = 0x001E,
+    /// PrepareKeyAttestation operation
+    PrepareKeyAttestation = 0x001F,
 }
 
 impl Opcode {
@@ -169,7 +173,9 @@ impl Opcode {
             | Opcode::PsaAeadDecrypt
             | Opcode::PsaCipherEncrypt
             | Opcode::PsaCipherDecrypt
-            | Opcode::PsaRawKeyAgreement => false,
+            | Opcode::PsaRawKeyAgreement
+            | Opcode::AttestKey
+            | Opcode::PrepareKeyAttestation => false,
         }
     }
 
@@ -201,7 +207,9 @@ impl Opcode {
             | Opcode::PsaAeadDecrypt
             | Opcode::PsaCipherEncrypt
             | Opcode::PsaCipherDecrypt
-            | Opcode::PsaRawKeyAgreement => false,
+            | Opcode::PsaRawKeyAgreement
+            | Opcode::AttestKey
+            | Opcode::PrepareKeyAttestation => false,
         }
     }
 


### PR DESCRIPTION
This commit adds the types for the new key attestation operations and
their conversions to/from protobuf.

Intended for https://github.com/parallaxsecond/parsec/issues/539