### PR TITLE
Configure bincode used in wire header serialization/deserialization 

### DIFF
--- a/src/requests/common/wire_header_1_0.rs
+++ b/src/requests/common/wire_header_1_0.rs
@@ -81,18 +81,18 @@ impl WireHeader {
     /// - if marshalling the header fails, `ResponseStatus::InvalidEncoding` is returned.
     /// - if writing the header bytes fails, `ResponseStatus::ConnectionError` is returned.
     pub fn write_to_stream<W: Write>(&self, stream: &mut W) -> Result<()> {
-        let serdes = bincode::DefaultOptions::new()
+        let serializer = bincode::DefaultOptions::new()
             .with_little_endian()
             .with_fixint_encoding();
 
-        stream.write_all(&serdes.serialize(&MAGIC_NUMBER)?)?;
+        stream.write_all(&serializer.serialize(&MAGIC_NUMBER)?)?;
 
-        stream.write_all(&serdes.serialize(&REQUEST_HDR_SIZE)?)?;
+        stream.write_all(&serializer.serialize(&REQUEST_HDR_SIZE)?)?;
 
-        stream.write_all(&serdes.serialize(&WIRE_PROTOCOL_VERSION_MAJ)?)?;
-        stream.write_all(&serdes.serialize(&WIRE_PROTOCOL_VERSION_MIN)?)?;
+        stream.write_all(&serializer.serialize(&WIRE_PROTOCOL_VERSION_MAJ)?)?;
+        stream.write_all(&serializer.serialize(&WIRE_PROTOCOL_VERSION_MIN)?)?;
 
-        stream.write_all(&serdes.serialize(&self)?)?;
+        stream.write_all(&serializer.serialize(&self)?)?;
 
         Ok(())
     }
@@ -140,10 +140,10 @@ impl WireHeader {
             return Err(ResponseStatus::WireProtocolVersionNotSupported);
         }
 
-        let serdes = bincode::DefaultOptions::new()
+        let deserializer = bincode::DefaultOptions::new()
             .with_little_endian()
             .with_fixint_encoding();
-        let wire_header: WireHeader = serdes.deserialize(&bytes)?;
+        let wire_header: WireHeader = deserializer.deserialize(&bytes)?;
 
         if wire_header.reserved1 != 0x00 || wire_header.reserved2 != 0x00 {
             Err(ResponseStatus::InvalidHeader)

--- a/src/requests/common/wire_header_1_0.rs
+++ b/src/requests/common/wire_header_1_0.rs
@@ -7,6 +7,7 @@ use crate::requests::common::MAGIC_NUMBER;
 use crate::requests::{ResponseStatus, Result};
 #[cfg(feature = "fuzz")]
 use arbitrary::Arbitrary;
+use bincode::Options;
 use log::error;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
@@ -80,14 +81,18 @@ impl WireHeader {
     /// - if marshalling the header fails, `ResponseStatus::InvalidEncoding` is returned.
     /// - if writing the header bytes fails, `ResponseStatus::ConnectionError` is returned.
     pub fn write_to_stream<W: Write>(&self, stream: &mut W) -> Result<()> {
-        stream.write_all(&bincode::serialize(&MAGIC_NUMBER)?)?;
+        let serdes = bincode::DefaultOptions::new()
+            .with_little_endian()
+            .with_fixint_encoding();
 
-        stream.write_all(&bincode::serialize(&REQUEST_HDR_SIZE)?)?;
+        stream.write_all(&serdes.serialize(&MAGIC_NUMBER)?)?;
 
-        stream.write_all(&bincode::serialize(&WIRE_PROTOCOL_VERSION_MAJ)?)?;
-        stream.write_all(&bincode::serialize(&WIRE_PROTOCOL_VERSION_MIN)?)?;
+        stream.write_all(&serdes.serialize(&REQUEST_HDR_SIZE)?)?;
 
-        stream.write_all(&bincode::serialize(&self)?)?;
+        stream.write_all(&serdes.serialize(&WIRE_PROTOCOL_VERSION_MAJ)?)?;
+        stream.write_all(&serdes.serialize(&WIRE_PROTOCOL_VERSION_MIN)?)?;
+
+        stream.write_all(&serdes.serialize(&self)?)?;
 
         Ok(())
     }
@@ -135,7 +140,10 @@ impl WireHeader {
             return Err(ResponseStatus::WireProtocolVersionNotSupported);
         }
 
-        let wire_header: WireHeader = bincode::deserialize(&bytes)?;
+        let serdes = bincode::DefaultOptions::new()
+            .with_little_endian()
+            .with_fixint_encoding();
+        let wire_header: WireHeader = serdes.deserialize(&bytes)?;
 
         if wire_header.reserved1 != 0x00 || wire_header.reserved2 != 0x00 {
             Err(ResponseStatus::InvalidHeader)

--- a/src/requests/request/mod.rs
+++ b/src/requests/request/mod.rs
@@ -229,6 +229,32 @@ mod tests {
     }
 
     #[test]
+    fn stream_to_fail_request_wrong_endians() {
+        let mut mock = test_utils::MockReadWrite {
+            buffer: get_request_bytes_big_endian_fixint_encoding(),
+        };
+        let response_status =
+            Request::read_from_stream(&mut mock, 1000).expect_err("Should have failed.");
+        assert_eq!(response_status, ResponseStatus::InvalidHeader);
+
+        let mut mock = test_utils::MockReadWrite {
+            buffer: get_request_bytes_big_endian_varint_encoding(),
+        };
+        let response_status =
+            Request::read_from_stream(&mut mock, 1000).expect_err("Should have failed.");
+        assert_eq!(response_status, ResponseStatus::InvalidHeader);
+    }
+    #[test]
+    fn stream_to_fail_request_wrong_int_encoding() {
+        let mut mock = test_utils::MockReadWrite {
+            buffer: get_request_bytes_little_endian_varint_encoding(),
+        };
+        let response_status =
+            Request::read_from_stream(&mut mock, 1000).expect_err("Should have failed.");
+        assert_eq!(response_status, ResponseStatus::InvalidHeader);
+    }
+
+    #[test]
     #[should_panic(expected = "Failed to read request")]
     fn failed_read() {
         let mut fail_mock = test_utils::MockFailReadWrite;
@@ -431,6 +457,80 @@ mod tests {
             0xAD, // WireHeader::reserved2
             0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, // RequestBody
             0xA0, 0xA1, 0xA2, 0xA3, 0xA4, // RequestAuth
+        ]
+    }
+    fn get_request_bytes_big_endian_fixint_encoding() -> Vec<u8> {
+        vec![
+            0x5E, 0xC0, 0xA7, 0x10, // MAGIC_NUMBER
+            0x00, 0x1E, // REQUEST_HDR_SIZE
+            0x01, // WIRE_PROTOCOL_VERSION_MAJ
+            0x00, // WIRE_PROTOCOL_VERSION_MIN
+            0x00, 0x00, // WireHeader::flags
+            0x00, // WireHeader::provider
+            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, // WireHeader::session
+            0x00, // WireHeader::content_type
+            0x00, // WireHeader::accept_type
+            0x01, // WireHeader::auth_type
+            0x00, 0x00, 0x00, 0x03, // WireHeader::body_len
+            0x00, 0x03, // WireHeader::auth_len
+            0x00, 0x00, 0x00, 0x01, // WireHeader::opcode
+            0x00, 0x00, // WireHeader::status
+            0x00, // WireHeader::reserved1
+            0x00, // WireHeader::reserved2
+            0x70, 0x80, 0x90, // RequestBody
+            0xa0, 0xb0, 0xc0, // RequestAuth
+        ]
+    }
+    fn get_request_bytes_little_endian_varint_encoding() -> Vec<u8> {
+        vec![
+            0xFC, // Encoding byte indicates that the following 4 bytes make a u32 int
+            //https://docs.rs/bincode/1.3.3/bincode/config/struct.VarintEncoding.html
+            0x5E, 0xC0, 0xA7, 0x10, // MAGIC_NUMBER
+            0x1E, // REQUEST_HDR_SIZE
+            0x01, // WIRE_PROTOCOL_VERSION_MAJ
+            0x00, // WIRE_PROTOCOL_VERSION_MIN
+            0x00, // WireHeader::flags
+            0x00, // WireHeader::provider
+            0xFD, // Encoding byte indicates that the following 8 bytes make a u64 int
+            //https://docs.rs/bincode/1.3.3/bincode/config/struct.VarintEncoding.html
+            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, // WireHeader::session
+            0x00, // WireHeader::content_type
+            0x00, // WireHeader::accept_type
+            0x01, // WireHeader::auth_type
+            0x03, // WireHeader::body_len
+            0x03, // WireHeader::auth_len
+            0x01, // WireHeader::opcode
+            0x00, // WireHeader::status
+            0x00, // WireHeader::reserved1
+            0x00, // WireHeader::reserved2
+            0x70, 0x80, 0x90, // RequestBody
+            0xA0, 0xB0, 0xC0, // RequestAuth
+        ]
+    }
+    fn get_request_bytes_big_endian_varint_encoding() -> Vec<u8> {
+        vec![
+            0xFC, // Encoding byte indicates that the following 4 bytes make a u32 int
+            //https://docs.rs/bincode/1.3.3/bincode/config/struct.VarintEncoding.html
+            0x10, 0xA7, 0xC0, 0x5E, // MAGIC_NUMBER
+            0x1E, // REQUEST_HDR_SIZE
+            0x01, // WIRE_PROTOCOL_VERSION_MAJ
+            0x00, // WIRE_PROTOCOL_VERSION_MIN
+            0x00, // WireHeader::flags
+            0x00, // WireHeader::provider
+            0xFD, // Encoding byte indicates that the following 8 bytes make a u64 int
+            //https://docs.rs/bincode/1.3.3/bincode/config/struct.VarintEncoding.html
+            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, // WireHeader::session
+            0x00, // WireHeader::content_type
+            0x00, // WireHeader::accept_type
+            0x01, // WireHeader::auth_type
+            0x03, // WireHeader::body_len
+            0x03, // WireHeader::auth_len
+            0x01, // WireHeader::opcode
+            0x00, // WireHeader::status
+            0x00, // WireHeader::reserved1
+            0x00, // WireHeader::reserved2
+            0x70, 0x80, 0x90, // RequestBody
+            0xA0, 0xB0, 0xC0, // RequestAuth
         ]
     }
 }

--- a/src/requests/request/mod.rs
+++ b/src/requests/request/mod.rs
@@ -135,25 +135,54 @@ mod tests {
     use super::*;
 
     #[test]
-    fn request_to_stream() {
+    fn request_1_to_stream() {
         let mut mock = test_utils::MockReadWrite { buffer: Vec::new() };
-        let request = get_request();
+        let request = get_request_1();
 
         request
             .write_to_stream(&mut mock)
             .expect("Failed to write request");
 
-        assert_eq!(mock.buffer, get_request_bytes());
+        assert_eq!(mock.buffer, get_request_1_bytes());
     }
 
     #[test]
-    fn stream_to_request() {
+    fn request_2_to_stream() {
+        let mut mock = test_utils::MockReadWrite { buffer: Vec::new() };
+        let request = get_request_2();
+
+        request
+            .write_to_stream(&mut mock)
+            .expect("Failed to write request");
+
+        assert_eq!(mock.buffer, get_request_2_bytes());
+    }
+
+    #[test]
+    fn stream_to_request_1() {
         let mut mock = test_utils::MockReadWrite {
-            buffer: get_request_bytes(),
+            buffer: get_request_1_bytes(),
         };
 
         let request = Request::read_from_stream(&mut mock, 1000).expect("Failed to read request");
-        let exp_req = get_request();
+        let exp_req = get_request_1();
+
+        assert_eq!(request.header, exp_req.header);
+        assert_eq!(request.body, exp_req.body);
+        assert_eq!(
+            request.auth.buffer.expose_secret(),
+            exp_req.auth.buffer.expose_secret()
+        );
+    }
+
+    #[test]
+    fn stream_to_request_2() {
+        let mut mock = test_utils::MockReadWrite {
+            buffer: get_request_2_bytes(),
+        };
+
+        let request = Request::read_from_stream(&mut mock, 1000).expect("Failed to read request");
+        let exp_req = get_request_2();
 
         assert_eq!(request.header, exp_req.header);
         assert_eq!(request.body, exp_req.body);
@@ -211,7 +240,7 @@ mod tests {
     #[should_panic(expected = "Request body too large")]
     fn body_too_large() {
         let mut mock = test_utils::MockReadWrite {
-            buffer: get_request_bytes(),
+            buffer: get_request_1_bytes(),
         };
 
         let _ = Request::read_from_stream(&mut mock, 0).expect("Request body too large");
@@ -220,7 +249,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Failed to write request")]
     fn failed_write() {
-        let request: Request = get_request();
+        let request: Request = get_request_1();
         let mut fail_mock = test_utils::MockFailReadWrite;
 
         request
@@ -230,7 +259,7 @@ mod tests {
 
     #[test]
     fn req_hdr_to_resp_hdr() {
-        let req_hdr = get_request().header;
+        let req_hdr = get_request_1().header;
         let resp_hdr: ResponseHeader = req_hdr.into();
 
         let mut resp_hdr_exp = ResponseHeader::new();
@@ -246,7 +275,7 @@ mod tests {
     #[test]
     fn wrong_version() {
         let mut mock = test_utils::MockReadWrite {
-            buffer: get_request_bytes(),
+            buffer: get_request_1_bytes(),
         };
         // Put an invalid version major field.
         mock.buffer[6] = 0xFF;
@@ -262,7 +291,7 @@ mod tests {
         );
     }
 
-    fn get_request() -> Request {
+    fn get_request_1() -> Request {
         let body = RequestBody::from_bytes(vec![0x70, 0x80, 0x90]);
         let auth = RequestAuth::new(vec![0xa0, 0xb0, 0xc0]);
         let header = RequestHeader {
@@ -276,35 +305,132 @@ mod tests {
         Request { header, body, auth }
     }
 
-    fn get_request_bytes() -> Vec<u8> {
+    fn get_request_2() -> Request {
+        let body = RequestBody::from_bytes(vec![0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5]);
+        let auth = RequestAuth::new(vec![0xA0, 0xA1, 0xA2, 0xA3, 0xA4]);
+        let header = RequestHeader {
+            provider: ProviderId::Core,
+            session: 0x88_99_AA_BB_CC_DD_EE_FF,
+            content_type: BodyType::Protobuf,
+            accept_type: BodyType::Protobuf,
+            auth_type: AuthType::Direct,
+            opcode: Opcode::Ping,
+        };
+        Request { header, body, auth }
+    }
+
+    fn get_request_1_bytes() -> Vec<u8> {
         vec![
-            0x10, 0xA7, 0xC0, 0x5E, 0x1e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x88, 0x77, 0x66,
-            0x55, 0x44, 0x33, 0x22, 0x11, 0x00, 0x00, 0x01, 0x03, 0x00, 0x00, 0x00, 0x03, 0x00,
-            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x70, 0x80, 0x90, 0xa0, 0xb0, 0xc0,
+            0x10, 0xA7, 0xC0, 0x5E, // MAGIC_NUMBER
+            0x1E, 0x00, // REQUEST_HDR_SIZE
+            0x01, // WIRE_PROTOCOL_VERSION_MAJ
+            0x00, // WIRE_PROTOCOL_VERSION_MIN
+            0x00, 0x00, // WireHeader::flags
+            0x00, // WireHeader::provider
+            0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, // WireHeader::session
+            0x00, // WireHeader::content_type
+            0x00, // WireHeader::accept_type
+            0x01, // WireHeader::auth_type
+            0x03, 0x00, 0x00, 0x00, // WireHeader::body_len
+            0x03, 0x00, // WireHeader::auth_len
+            0x01, 0x00, 0x00, 0x00, // WireHeader::opcode
+            0x00, 0x00, // WireHeader::status
+            0x00, // WireHeader::reserved1
+            0x00, // WireHeader::reserved2
+            0x70, 0x80, 0x90, // RequestBody
+            0xA0, 0xB0, 0xC0, // RequestAuth
+        ]
+    }
+
+    fn get_request_2_bytes() -> Vec<u8> {
+        vec![
+            0x10, 0xA7, 0xC0, 0x5E, // MAGIC_NUMBER
+            0x1E, 0x00, // REQUEST_HDR_SIZE
+            0x01, // WIRE_PROTOCOL_VERSION_MAJ
+            0x00, // WIRE_PROTOCOL_VERSION_MIN
+            0x00, 0x00, // WireHeader::flags
+            0x00, // WireHeader::provider
+            0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA, 0x99, 0x88, // WireHeader::session
+            0x00, // WireHeader::content_type
+            0x00, // WireHeader::accept_type
+            0x01, // WireHeader::auth_type
+            0x06, 0x00, 0x00, 0x00, // WireHeader::body_len
+            0x05, 0x00, // WireHeader::auth_len
+            0x01, 0x00, 0x00, 0x00, // WireHeader::opcode
+            0x00, 0x00, // WireHeader::status
+            0x00, // WireHeader::reserved1
+            0x00, // WireHeader::reserved2
+            0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, // RequestBody
+            0xA0, 0xA1, 0xA2, 0xA3, 0xA4, // RequestAuth
         ]
     }
 
     fn get_request_bytes_reserved_fields_both_not_zero() -> Vec<u8> {
         // reserved fields set to 0xDEAD
         vec![
-            0x10, 0xA7, 0xC0, 0x5E, 0x1e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x88, 0x77, 0x66,
-            0x55, 0x44, 0x33, 0x22, 0x11, 0x00, 0x00, 0x01, 0x03, 0x00, 0x00, 0x00, 0x03, 0x00,
-            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0xDE, 0xAD, 0x70, 0x80, 0x90, 0xa0, 0xb0, 0xc0,
+            0x10, 0xA7, 0xC0, 0x5E, // MAGIC_NUMBER
+            0x1E, 0x00, // REQUEST_HDR_SIZE
+            0x01, // WIRE_PROTOCOL_VERSION_MAJ
+            0x00, // WIRE_PROTOCOL_VERSION_MIN
+            0x00, 0x00, // WireHeader::flags
+            0x00, // WireHeader::provider
+            0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA, 0x99, 0x88, // WireHeader::session
+            0x00, // WireHeader::content_type
+            0x00, // WireHeader::accept_type
+            0x01, // WireHeader::auth_type
+            0x06, 0x00, 0x00, 0x00, // WireHeader::body_len
+            0x05, 0x00, // WireHeader::auth_len
+            0x01, 0x00, 0x00, 0x00, // WireHeader::opcode
+            0x00, 0x00, // WireHeader::status
+            0xDE, // WireHeader::reserved1
+            0xAD, // WireHeader::reserved2
+            0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, // RequestBody
+            0xA0, 0xA1, 0xA2, 0xA3, 0xA4, // RequestAuth
         ]
     }
 
     fn get_request_bytes_reserved_fields_first_not_zero() -> Vec<u8> {
         vec![
-            0x10, 0xA7, 0xC0, 0x5E, 0x1e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x88, 0x77, 0x66,
-            0x55, 0x44, 0x33, 0x22, 0x11, 0x00, 0x00, 0x01, 0x03, 0x00, 0x00, 0x00, 0x03, 0x00,
-            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0xDE, 0x00, 0x70, 0x80, 0x90, 0xa0, 0xb0, 0xc0,
+            0x10, 0xA7, 0xC0, 0x5E, // MAGIC_NUMBER
+            0x1E, 0x00, // REQUEST_HDR_SIZE
+            0x01, // WIRE_PROTOCOL_VERSION_MAJ
+            0x00, // WIRE_PROTOCOL_VERSION_MIN
+            0x00, 0x00, // WireHeader::flags
+            0x00, // WireHeader::provider
+            0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA, 0x99, 0x88, // WireHeader::session
+            0x00, // WireHeader::content_type
+            0x00, // WireHeader::accept_type
+            0x01, // WireHeader::auth_type
+            0x06, 0x00, 0x00, 0x00, // WireHeader::body_len
+            0x05, 0x00, // WireHeader::auth_len
+            0x01, 0x00, 0x00, 0x00, // WireHeader::opcode
+            0x00, 0x00, // WireHeader::status
+            0xDE, // WireHeader::reserved1
+            0x00, // WireHeader::reserved2
+            0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, // RequestBody
+            0xA0, 0xA1, 0xA2, 0xA3, 0xA4, // RequestAuth
         ]
     }
     fn get_request_bytes_reserved_fields_second_not_zero() -> Vec<u8> {
         vec![
-            0x10, 0xA7, 0xC0, 0x5E, 0x1e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x88, 0x77, 0x66,
-            0x55, 0x44, 0x33, 0x22, 0x11, 0x00, 0x00, 0x01, 0x03, 0x00, 0x00, 0x00, 0x03, 0x00,
-            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xAD, 0x70, 0x80, 0x90, 0xa0, 0xb0, 0xc0,
+            0x10, 0xA7, 0xC0, 0x5E, // MAGIC_NUMBER
+            0x1E, 0x00, // REQUEST_HDR_SIZE
+            0x01, // WIRE_PROTOCOL_VERSION_MAJ
+            0x00, // WIRE_PROTOCOL_VERSION_MIN
+            0x00, 0x00, // WireHeader::flags
+            0x00, // WireHeader::provider
+            0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA, 0x99, 0x88, // WireHeader::session
+            0x00, // WireHeader::content_type
+            0x00, // WireHeader::accept_type
+            0x01, // WireHeader::auth_type
+            0x06, 0x00, 0x00, 0x00, // WireHeader::body_len
+            0x05, 0x00, // WireHeader::auth_len
+            0x01, 0x00, 0x00, 0x00, // WireHeader::opcode
+            0x00, 0x00, // WireHeader::status
+            0x00, // WireHeader::reserved1
+            0xAD, // WireHeader::reserved2
+            0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, // RequestBody
+            0xA0, 0xA1, 0xA2, 0xA3, 0xA4, // RequestAuth
         ]
     }
 }

--- a/src/requests/response/mod.rs
+++ b/src/requests/response/mod.rs
@@ -114,27 +114,51 @@ mod tests {
     use super::*;
 
     #[test]
-    fn response_to_stream() {
+    fn response_1_to_stream() {
         let mut mock = test_utils::MockReadWrite { buffer: Vec::new() };
-        let response = get_response();
+        let response = get_response_1();
 
         response
             .write_to_stream(&mut mock)
             .expect("Failed to write response");
 
-        assert_eq!(mock.buffer, get_response_bytes());
+        assert_eq!(mock.buffer, get_response_1_bytes());
     }
 
     #[test]
-    fn stream_to_response() {
+    fn response_2_to_stream() {
+        let mut mock = test_utils::MockReadWrite { buffer: Vec::new() };
+        let response = get_response_2();
+
+        response
+            .write_to_stream(&mut mock)
+            .expect("Failed to write response");
+
+        assert_eq!(mock.buffer, get_response_2_bytes());
+    }
+
+    #[test]
+    fn stream_to_response_1() {
         let mut mock = test_utils::MockReadWrite {
-            buffer: get_response_bytes(),
+            buffer: get_response_1_bytes(),
         };
 
         let response =
             Response::read_from_stream(&mut mock, 1000).expect("Failed to read response");
 
-        assert_eq!(response, get_response());
+        assert_eq!(response, get_response_1());
+    }
+
+    #[test]
+    fn stream_to_response_2() {
+        let mut mock = test_utils::MockReadWrite {
+            buffer: get_response_2_bytes(),
+        };
+
+        let response =
+            Response::read_from_stream(&mut mock, 1000).expect("Failed to read response");
+
+        assert_eq!(response, get_response_2());
     }
 
     #[test]
@@ -149,7 +173,7 @@ mod tests {
     #[should_panic(expected = "Response body too large")]
     fn body_too_large() {
         let mut mock = test_utils::MockReadWrite {
-            buffer: get_response_bytes(),
+            buffer: get_response_1_bytes(),
         };
 
         let _ = Response::read_from_stream(&mut mock, 0).expect("Response body too large");
@@ -158,7 +182,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Failed to write response")]
     fn failed_write() {
-        let response: Response = get_response();
+        let response: Response = get_response_1();
         let mut fail_mock = test_utils::MockFailReadWrite;
 
         response
@@ -169,7 +193,7 @@ mod tests {
     #[test]
     fn wrong_version() {
         let mut mock = test_utils::MockReadWrite {
-            buffer: get_response_bytes(),
+            buffer: get_response_1_bytes(),
         };
         // Put an invalid version major field.
         mock.buffer[6] = 0xFF;
@@ -185,7 +209,7 @@ mod tests {
         );
     }
 
-    fn get_response() -> Response {
+    fn get_response_1() -> Response {
         let body = ResponseBody::from_bytes(vec![0x70, 0x80, 0x90]);
         let header = ResponseHeader {
             provider: ProviderId::Core,
@@ -197,11 +221,59 @@ mod tests {
         Response { header, body }
     }
 
-    fn get_response_bytes() -> Vec<u8> {
+    fn get_response_2() -> Response {
+        let body = ResponseBody::from_bytes(vec![0xB0, 0xB1, 0xB2, 0xB3]);
+        let header = ResponseHeader {
+            provider: ProviderId::Core,
+            session: 0x88_99_AA_BB_CC_DD_EE_FF,
+            content_type: BodyType::Protobuf,
+            opcode: Opcode::Ping,
+            status: ResponseStatus::Success,
+        };
+        Response { header, body }
+    }
+
+    fn get_response_1_bytes() -> Vec<u8> {
         vec![
-            0x10, 0xA7, 0xC0, 0x5E, 0x1e, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x88, 0x77, 0x66,
-            0x55, 0x44, 0x33, 0x22, 0x11, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x70, 0x80, 0x90,
+            0x10, 0xA7, 0xC0, 0x5E, // MAGIC_NUMBER
+            0x1E, 0x00, // REQUEST_HDR_SIZE
+            0x01, // WIRE_PROTOCOL_VERSION_MAJ
+            0x00, // WIRE_PROTOCOL_VERSION_MIN
+            0x00, 0x00, // WireHeader::flags
+            0x00, // WireHeader::provider
+            0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, // WireHeader::session
+            0x00, // WireHeader::content_type
+            0x00, // WireHeader::accept_type
+            0x00, // WireHeader::auth_type
+            0x03, 0x00, 0x00, 0x00, // WireHeader::body_len
+            0x00, 0x00, // WireHeader::auth_len
+            0x01, 0x00, 0x00, 0x00, // WireHeader::opcode
+            0x00, 0x00, // WireHeader::status
+            0x00, // WireHeader::reserved1
+            0x00, // WireHeader::reserved2
+            0x70, 0x80, 0x90, // ResponseBody
+        ]
+    }
+
+    fn get_response_2_bytes() -> Vec<u8> {
+        vec![
+            0x10, 0xA7, 0xC0, 0x5E, // MAGIC_NUMBER
+            0x1E, 0x00, // REQUEST_HDR_SIZE
+            0x01, // WIRE_PROTOCOL_VERSION_MAJ
+            0x00, // WIRE_PROTOCOL_VERSION_MIN
+            0x00, 0x00, // WireHeader::flags
+            0x00, // WireHeader::provider
+            0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA, 0x99, 0x88, // WireHeader::session
+            0x00, // WireHeader::content_type
+            0x00, // WireHeader::accept_type
+            0x00, // WireHeader::auth_type
+            0x04, 0x00, 0x00, 0x00, // WireHeader::body_len
+            0x00, 0x00, // WireHeader::auth_len
+            0x01, 0x00, 0x00, 0x00, // WireHeader::opcode
+            0x00, 0x00, // WireHeader::status
+            0x00, // WireHeader::reserved1
+            0x00, // WireHeader::reserved2
+            0xB0, 0xB1, 0xB2, 0xB3, // ResponseBody
         ]
     }
 }


### PR DESCRIPTION
Explicitly configure `bincode` to use little-endian and fixed integer encoding

Fixes: #115