### PR TITLE
Fix clippy warnings and ignore those under generated ops

### DIFF
--- a/src/operations_protobuf/generated_ops/mod.rs
+++ b/src/operations_protobuf/generated_ops/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::derive_partial_eq_without_eq)]
 pub mod psa_sign_hash;
 pub mod psa_verify_hash;
 pub mod psa_sign_message;

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -69,7 +69,7 @@ impl TryFrom<u8> for ProviderId {
 ///
 /// Passed in headers as `content_type` and `accept_type`.
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
-#[derive(FromPrimitive, Copy, Clone, Debug, PartialEq)]
+#[derive(FromPrimitive, Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub enum BodyType {
     /// Protobuf format for operations.

--- a/src/requests/request/request_body.rs
+++ b/src/requests/request/request_body.rs
@@ -11,7 +11,7 @@ use zeroize::Zeroize;
 ///
 /// Hides the contents and keeps them immutable.
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
-#[derive(Debug, PartialEq, Zeroize)]
+#[derive(Debug, PartialEq, Eq, Zeroize)]
 #[zeroize(drop)]
 pub struct RequestBody {
     buffer: Vec<u8>,

--- a/src/requests/request/request_header.rs
+++ b/src/requests/request/request_header.rs
@@ -13,7 +13,7 @@ use std::convert::TryFrom;
 /// Fields that are not relevant for application development (e.g. magic number) are
 /// not copied across from the raw header.
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct RequestHeader {
     /// Provider ID value
     pub provider: ProviderId,

--- a/src/requests/response/mod.rs
+++ b/src/requests/response/mod.rs
@@ -20,7 +20,7 @@ pub use response_header::ResponseHeader;
 pub use super::common::wire_header_1_0::WireHeader as RawHeader;
 
 /// Native representation of the response wire format.
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct Response {
     /// Header of the response, containing the response status.
     pub header: ResponseHeader,

--- a/src/requests/response/response_body.rs
+++ b/src/requests/response/response_body.rs
@@ -9,7 +9,7 @@ use zeroize::Zeroize;
 /// Wrapper around the body of a response.
 ///
 /// Hides the contents and keeps them immutable.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Zeroize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Zeroize)]
 #[zeroize(drop)]
 pub struct ResponseBody {
     buffer: Vec<u8>,

--- a/src/requests/response/response_header.rs
+++ b/src/requests/response/response_header.rs
@@ -9,7 +9,7 @@ use std::convert::TryFrom;
 ///
 /// Fields that are not relevant for application development (e.g. magic number) are
 /// not copied across from the raw header.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct ResponseHeader {
     /// Provider ID value
     pub provider: ProviderId,

--- a/src/requests/response_status.rs
+++ b/src/requests/response_status.rs
@@ -11,7 +11,7 @@ use std::fmt;
 /// See the [status
 /// code](https://parallaxsecond.github.io/parsec-book/parsec_client/status_codes.html) page for a
 /// broader description of these codes.
-#[derive(Copy, Clone, Debug, PartialEq, FromPrimitive)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, FromPrimitive)]
 #[repr(u16)]
 pub enum ResponseStatus {
     /// Successful operation


### PR DESCRIPTION
Fix the recent Clippy warnings introduced in version 1.63
Ignore the warnings coming from the `protobuf`  code generation

Signed-off-by: Mohamed Omar Asaker <mohamed.omarasaker@arm.com>