### PR TITLE
Do not derive Arbitrary for types not implementing it

### DIFF
--- a/src/operations/psa_asymmetric_decrypt.rs
+++ b/src/operations/psa_asymmetric_decrypt.rs
@@ -7,8 +7,6 @@
 use super::psa_key_attributes::Attributes;
 use crate::operations::psa_algorithm::AsymmetricEncryption;
 use crate::requests::ResponseStatus;
-#[cfg(feature = "fuzz")]
-use arbitrary::Arbitrary;
 use derivative::Derivative;
 
 /// Native object for asymmetric decryption operations.

--- a/src/requests/request/mod.rs
+++ b/src/requests/request/mod.rs
@@ -7,8 +7,6 @@ use super::common::wire_header_1_0::WireHeader as Raw;
 use super::response::ResponseHeader;
 use crate::requests::{ResponseStatus, Result};
 use crate::secrecy::ExposeSecret;
-#[cfg(feature = "fuzz")]
-use arbitrary::Arbitrary;
 use derivative::Derivative;
 use log::error;
 use std::convert::{TryFrom, TryInto};
@@ -26,7 +24,6 @@ pub use request_header::RequestHeader;
 pub use super::common::wire_header_1_0::WireHeader as RawHeader;
 
 /// Representation of the request wire format.
-#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub struct Request {

--- a/src/requests/request/request_auth.rs
+++ b/src/requests/request/request_auth.rs
@@ -2,14 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::requests::Result;
 use crate::secrecy::{ExposeSecret, Secret};
-#[cfg(feature = "fuzz")]
-use arbitrary::Arbitrary;
 use std::io::{Read, Write};
 
 /// Wrapper around the authentication value of a request.
 ///
 /// Hides the contents and keeps them immutable.
-#[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 #[allow(missing_debug_implementations)]
 pub struct RequestAuth {
     /// Buffer holding the authentication token as a byte vector


### PR DESCRIPTION
A requirement for deriving Arbitrary is that every member of the struct implement Arbitrary. This is not the case for struct Request and RequestAuth.

Caught by testing with `cargo test --all-features`.