### PR TITLE
Bump psa_crypto and update parsec_interface crate version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.28.0](https://github.com/parallaxsecond/parsec-interface-rs/tree/0.28.0) (2023-03-13)
+
+[Full Changelog](https://github.com/parallaxsecond/parsec-interface-rs/compare/0.27.0...0.28.0)
+
+**Merged pull requests:**
+
+- Fix CI issues [\#136](https://github.com/parallaxsecond/parsec-interface-rs/pull/136) ([gowthamsk-arm](https://github.com/gowthamsk-arm))
+- Do not derive Arbitrary for types not implementing it [\#135](https://github.com/parallaxsecond/parsec-interface-rs/pull/135) ([ema](https://github.com/ema))
+- Update to remove const\_err [\#134](https://github.com/parallaxsecond/parsec-interface-rs/pull/134) ([marcsvll](https://github.com/marcsvll))
+
 ## [0.27.0](https://github.com/parallaxsecond/parsec-interface-rs/tree/0.27.0) (2022-09-09)
 
 [Full Changelog](https://github.com/parallaxsecond/parsec-interface-rs/compare/0.26.0...0.27.0)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parsec-interface"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Parsec Project Contributors"]
 description = "Parsec interface library to communicate using the wire protocol"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ prost = "0.8.0"
 arbitrary = { version = "0.4.6", features = ["derive"], optional = true }
 uuid = "0.8.1"
 log = "0.4.11"
-psa-crypto = { version = "0.9.2", default-features = false }
+psa-crypto = { version = "0.10.0", default-features = false }
 zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
 secrecy = { version = "0.7.0", features = ["serde"] }
 derivative = "2.1.1"


### PR DESCRIPTION
This MR does the following:

- Bump psa-crypto
- Update crate version
- Add changelog

Signed-off-by: Gowtham Suresh Kumar <gowtham.sureshkumar@arm.com>