### PR TITLE
Fix ci errors/warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
     overflowing_literals,
     path_statements,
     patterns_in_fns_without_body,
-    private_in_public,
     unconditional_recursion,
     unused,
     unused_allocation,

--- a/src/operations/utils_deprecated_primitives.rs
+++ b/src/operations/utils_deprecated_primitives.rs
@@ -464,14 +464,14 @@ mod tests {
     #[test]
     fn deprecated_algorithms() {
         for algo in get_deprecated_algorithms() {
-            assert!(is_algorithm_deprecated(algo), "algorithm: {algo:?}");
+            assert!(is_algorithm_deprecated(algo), "algorithm: {:?}", algo);
         }
     }
 
     #[test]
     fn non_deprecated_algorithms() {
         for algo in get_selection_non_deprecated_algorithms() {
-            assert!(!is_algorithm_deprecated(algo), "algorithm: {algo:?}");
+            assert!(!is_algorithm_deprecated(algo), "algorithm: {:?}", algo);
         }
     }
 
@@ -517,7 +517,9 @@ mod tests {
         for (ktype, ksize) in test_keys {
             assert!(
                 is_key_deprecated(ktype, ksize),
-                "key: ({ktype:?} : {ksize:?})"
+                "key: ({:?} : {:?})",
+                ktype,
+                ksize
             );
         }
     }
@@ -569,7 +571,9 @@ mod tests {
         for (ktype, ksize) in test_keys {
             assert!(
                 !is_key_deprecated(ktype, ksize),
-                "key: ({ktype:?} : {ksize:?})"
+                "key: ({:?} : {:?})",
+                ktype,
+                ksize
             );
         }
     }

--- a/src/requests/common/wire_header_1_0.rs
+++ b/src/requests/common/wire_header_1_0.rs
@@ -10,7 +10,6 @@ use arbitrary::Arbitrary;
 use bincode::Options;
 use log::error;
 use serde::{Deserialize, Serialize};
-use std::convert::TryFrom;
 use std::io::{Read, Write};
 
 const WIRE_PROTOCOL_VERSION_MAJ: u8 = 1;
@@ -120,7 +119,7 @@ impl WireHeader {
         }
 
         let hdr_size = get_from_stream!(stream, u16);
-        let mut bytes = vec![0_u8; usize::try_from(hdr_size)?];
+        let mut bytes = vec![0_u8; usize::from(hdr_size)];
         stream.read_exact(&mut bytes)?;
         if hdr_size != REQUEST_HDR_SIZE {
             error!(

--- a/src/requests/request/mod.rs
+++ b/src/requests/request/mod.rs
@@ -94,7 +94,7 @@ impl Request {
             return Err(ResponseStatus::BodySizeExceedsLimit);
         }
         let body = RequestBody::read_from_stream(stream, body_len)?;
-        let auth = RequestAuth::read_from_stream(stream, usize::try_from(raw_header.auth_len)?)?;
+        let auth = RequestAuth::read_from_stream(stream, usize::from(raw_header.auth_len))?;
 
         Ok(Request {
             header: raw_header.try_into()?,


### PR DESCRIPTION
This PR fixes the following trivial CI warnings and errors:

1. Use infallible `from` instead of `try_from`
2. Fix unused formatting placeholder warning
3. Drop `private_in_public` lint as it has been removed

Signed-off-by: Gowtham Suresh Kumar <gowtham.sureshkumar@arm.com>