### PR TITLE
Use Rust 1.78

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["parsec", "interface", "serialization"]
 categories = ["encoding"]
 edition = "2018"
-rust-version = "1.66.0"
+rust-version = "1.78.0"
 
 [build-dependencies]
 prost-build = { version = "0.9.0", optional = true }

--- a/src/operations/psa_asymmetric_decrypt.rs
+++ b/src/operations/psa_asymmetric_decrypt.rs
@@ -147,7 +147,7 @@ mod tests {
                 key_name: String::from("some key"),
                 alg: AsymmetricEncryption::RsaPkcs1v15Crypt,
                 ciphertext: Zeroizing::new(vec![0xff, 32]),
-                salt: Some(zeroize::Zeroizing::new(vec![0xff, 32])),
+                salt: Some(Zeroizing::new(vec![0xff, 32])),
             })
             .validate(get_attrs())
             .unwrap_err(),

--- a/src/operations/psa_import_key.rs
+++ b/src/operations/psa_import_key.rs
@@ -22,7 +22,7 @@ pub struct Operation {
     // Debug is not derived for this because it could expose secrets if printed or logged
     // somewhere
     #[derivative(Debug = "ignore")]
-    pub data: crate::secrecy::Secret<Vec<u8>>,
+    pub data: secrecy::Secret<Vec<u8>>,
 }
 
 /// Native object for the result of a cryptographic key import operation.

--- a/src/operations/psa_raw_key_agreement.rs
+++ b/src/operations/psa_raw_key_agreement.rs
@@ -29,7 +29,7 @@ pub struct Result {
     /// `data` holds the bytes defining the key, formatted as specified
     /// by the provider for which the request was made.
     #[derivative(Debug = "ignore")]
-    pub shared_secret: crate::secrecy::Secret<Vec<u8>>,
+    pub shared_secret: secrecy::Secret<Vec<u8>>,
 }
 
 impl Operation {

--- a/src/operations_protobuf/convert_psa_cipher_decrypt.rs
+++ b/src/operations_protobuf/convert_psa_cipher_decrypt.rs
@@ -72,7 +72,7 @@ mod test {
         let mut proto: OperationProto = Default::default();
         let message = vec![0x11, 0x22, 0x33];
         let key_name = "test name".to_string();
-        let proto_alg = psa_crypto::types::algorithm::Cipher::StreamCipher;
+        let proto_alg = Cipher::StreamCipher;
         proto.ciphertext = message.clone();
         proto.alg = convert_psa_algorithm::cipher_to_i32(proto_alg);
         proto.key_name = key_name.clone();

--- a/src/operations_protobuf/convert_psa_cipher_encrypt.rs
+++ b/src/operations_protobuf/convert_psa_cipher_encrypt.rs
@@ -71,7 +71,7 @@ mod test {
         let mut proto: OperationProto = Default::default();
         let message = vec![0x11, 0x22, 0x33];
         let key_name = "test name".to_string();
-        let proto_alg = psa_crypto::types::algorithm::Cipher::StreamCipher;
+        let proto_alg = Cipher::StreamCipher;
         proto.plaintext = message.clone();
         proto.alg = convert_psa_algorithm::cipher_to_i32(proto_alg);
         proto.key_name = key_name.clone();

--- a/src/operations_protobuf/convert_psa_export_key.rs
+++ b/src/operations_protobuf/convert_psa_export_key.rs
@@ -124,7 +124,7 @@ mod test {
     #[test]
     fn resp_export_pk_e2e() {
         let result = Result {
-            data: secrecy::Secret::new(vec![0x11, 0x22, 0x33]),
+            data: Secret::new(vec![0x11, 0x22, 0x33]),
         };
         let body = CONVERTER
             .result_to_body(NativeResult::PsaExportKey(result))

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -31,7 +31,7 @@ then
 fi
 if cargo clippy -h
 then
-	cargo clippy --all-targets -- -D clippy::all -D clippy::cargo
+	cargo clippy --all-targets -- -D clippy::cargo
 fi
 
 ############################


### PR DESCRIPTION
Follow suggestsions from the compiler.

Disable clippy::all lints for now

Fixes: #152
Signed-off-by: Reinhard Tartler <siretart@gmail.com>
